### PR TITLE
fix allows; add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/coredns/policy
+
+go 1.12


### PR DESCRIPTION
Fixes response for allows, sending the answer to client (previously an answerless response was sent).
Adds an empty go.mod - this is needed to be able to, for example, "replace" policy with a local instance in go modules.