### PR TITLE
WIP - Themis plugin an add-on for Firewall plugin

### DIFF
--- a/plugin/themis/README.md
+++ b/plugin/themis/README.md
@@ -1,0 +1,81 @@
+# coredns-themis
+Plugin Themis to embed the policy engine into Firewall plugin
+
+## Syntax
+
+~~~ txt
+policy {
+    endpoint ADDR_1, ADDR_2, ... ADDR_N
+    attr NAME LABEL [DSTTYPE]
+    ...
+    debug_query_suffix SUFFIX
+    debug_id ID
+    streams COUNT
+    transfer ATTR_1, ATTR_2, ... ATTR_N
+    log
+    max_request_size [[auto] SIZE]
+    max_response_attributes auto | COUNT
+    cache [TTL [SIZE]]
+}
+~~~
+
+Option endpoint defines set of PDP addresses
+
+Option attr is used for assigning labels into PDP attributes.
+
+Valid SRCTYPE are hex (default), bytes, ip.
+
+Valid DSTTYPE depends on Themis PDP implementation, ATM is supported string (default), address.
+
+Params SIZE, START, END is supported only for SRCTYPE = hex.
+
+Set param SIZE to value > 0 enables edns0 option data size check.
+
+Param START and END (last data byte index + 1) allow to get separate part of edns0 option data.
+
+Option debug_query_suffix SUFFIX (should have dot at the end) enables debug query feature.
+
+Option debug_id set string that is used for debug query response as unique id for determine what CoreDNS instance replies on the request.
+
+Option streams set gRPC streams count for PDP connection.
+
+Option transfer defines set of attributes (from domain validation response) that should be inserted into IP validation request.
+
+Option dnstap defines attributes to be included in extra field of DNStap message if received from PDP.
+
+Option passthrough defines set of domain name suffixes, domain that contains one of these is resolved without validation, each suffix should have dot at the end.
+
+Option connection_timeout sets timeout for query validation when no PDP server are available. Negative value or "no" keyword means wait forever. This is default behavior. With zero timeout validation fails instantly if there is no PDP servers. The option works only if gRPC streams are greater than 0.
+
+Option log enables log PDP request and response
+
+Option max_request_size sets maximum buffer size in bytes for serialized request. Too high limit makes the plugin to allocate too much memory while too small can lead to buffer overflow errors on validation. If "auto" is set plugin allocates required amount of bytes for each request. In case of both "auto" and SIZE, SIZE doesn't limit request buffer but used for cache allocations. 
+
+Option max_response_attributes sets maximum number of attributes expected from PDP. If value is "auto" plugin allocates necessary attribuets for each PDP response.
+
+Option cache enables decision cache. TTL default value is 10 minutes. SIZE limits memory cache takes to given number of megabytes. If it isn't provided cache can grow until application crashes due to out of memory.
+
+## Example
+
+~~~ txt
+policy {
+    endpoint 10.0.0.7:1234, 10.0.0.8:1234
+    attr client_id request/client_id
+    attr group_id request/group_id
+    attr uid request/another_id
+    attr source_ip request/source_ip address 
+    attr client_name request/client_name
+    debug_query_suffix debug.
+    debug_id instance_1
+    streams 100
+    transfer gid uid
+    log
+}
+~~~
+
+In this case edns0 options with code 0xffee is splitted into two values - client_id (first 16 bytes) and group_id (last 16 bytes), option should have size 32 bytes otherwise client_id and group_id is not parsed.
+
+Dig command example for debug query:
+~~~ txt
+dig @127.0.0.1 msn.com.debug txt ch
+~~~

--- a/plugin/themis/attrholder.go
+++ b/plugin/themis/attrholder.go
@@ -114,7 +114,7 @@ func makeAssignmentByType(o *attrSetting, value string) (pdp.AttributeAssignment
 	case "string":
 		return pdp.MakeStringAssignment(o.name, value), true
 	}
-	panic(fmt.Errorf("unknown attribute type %d", o.attrType))
+	panic(fmt.Errorf("unknown attribute type %s", o.attrType))
 }
 
 func (ah *attrHolder) addDnRes(r *pdp.Response, custAttrs map[string]custAttr) {

--- a/plugin/themis/attrholder.go
+++ b/plugin/themis/attrholder.go
@@ -1,0 +1,264 @@
+package themisplugin
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strconv"
+
+	"context"
+	"strings"
+
+	"github.com/coredns/coredns/plugin/metadata"
+	"github.com/coredns/policy/plugin/firewall/policy"
+	rq "github.com/coredns/policy/plugin/pkg/rqdata"
+	"github.com/infobloxopen/go-trees/domain"
+	"github.com/infobloxopen/themis/pdp"
+	"github.com/miekg/dns"
+)
+
+var emptyCtx *pdp.Context
+
+type attrSetting struct {
+	name     string
+	label    string
+	attrType string
+	metrics  bool
+}
+
+type attrHolder struct {
+	dn string
+
+	dnReq []pdp.AttributeAssignment
+	dnRes []pdp.AttributeAssignment
+
+	transfer []pdp.AttributeAssignment
+
+	ipReq []pdp.AttributeAssignment
+	ipRes []pdp.AttributeAssignment
+
+	dnstap []pdp.AttributeAssignment
+
+	action byte
+	dst    string
+}
+
+func init() {
+	emptyCtx, _ = pdp.NewContext(nil, 0, nil)
+}
+
+func setAttrRequestValueMetadata(label string) {
+
+}
+
+func newAttrHolderWithContext(ctx context.Context, xtr *rq.Extractor, optMap []*attrSetting, ag *AttrGauge) *attrHolder {
+
+	hdrCount := ednsAttrsStart
+	qName, _ := xtr.Value("name")
+	qType, _ := xtr.Value("qtype")
+	dn, err := domain.MakeNameFromString(qName)
+	if err != nil {
+		panic(fmt.Errorf("Can't treat %q as domain name: %s", qName, err))
+	}
+
+	clientIP, _ := xtr.Value("remote")
+	var srcIP = net.IP(nil)
+	if clientIP != "" {
+		srcIP = net.ParseIP(clientIP)
+	}
+	if srcIP != nil {
+		hdrCount++
+	}
+
+	ah := &attrHolder{
+		dn:    qName,
+		dnReq: make([]pdp.AttributeAssignment, hdrCount, 8),
+	}
+
+	ah.dnReq[0] = pdp.MakeStringAssignment(attrNameType, typeValueQuery)
+	ah.dnReq[1] = pdp.MakeDomainAssignment(attrNameDomainName, dn)
+	ah.dnReq[2] = pdp.MakeStringAssignment(attrNameDNSQtype, strconv.FormatUint(uint64(dns.StringToType[qType]), 16))
+
+	if srcIP != nil {
+		ah.dnReq[3] = pdp.MakeAddressAssignment(attrNameSourceIP, srcIP)
+	}
+
+	for _, o := range optMap {
+		f := metadata.ValueFunc(ctx, o.label)
+		if f == nil {
+			continue
+		}
+		value := f()
+		if value == "" {
+			continue
+		}
+		if a, ok := makeAssignmentByType(o, value); ok {
+			if o.name == attrNameSourceIP && srcIP != nil {
+				ah.dnReq[3] = a
+			} else {
+				ah.dnReq = append(ah.dnReq, a)
+				if o.metrics && ag != nil {
+					ag.Inc(a)
+				}
+			}
+		}
+	}
+
+	return ah
+}
+
+func makeAssignmentByType(o *attrSetting, value string) (pdp.AttributeAssignment, bool) {
+	switch strings.ToLower(o.attrType) {
+	case "address":
+		return pdp.MakeAddressAssignment(o.name, net.ParseIP(value)), true
+	case "string":
+		return pdp.MakeStringAssignment(o.name, value), true
+	}
+	panic(fmt.Errorf("unknown attribute type %d", o.attrType))
+}
+
+func (ah *attrHolder) addDnRes(r *pdp.Response, custAttrs map[string]custAttr) {
+	oCount := len(r.Obligations)
+
+	switch r.Effect {
+	default:
+		log.Printf("[ERROR] PDP Effect: %s, Reason: %s", pdp.EffectNameFromEnum(r.Effect), r.Status)
+		ah.action = policy.TypeNone
+
+	case pdp.EffectPermit:
+		ah.action = policy.TypeAllow
+
+		i := 0
+		for i < oCount {
+			o := r.Obligations[i]
+
+			id := o.GetID()
+			switch id {
+			case attrNameLog:
+				//ah.action = policy.TypeLog
+
+			default:
+				if t, ok := custAttrs[id]; ok {
+					ah.putCustomAttr(o, t)
+
+					if t.isEdns() {
+						oCount--
+						r.Obligations[i] = r.Obligations[oCount]
+						continue
+					}
+				}
+			}
+
+			i++
+		}
+
+	case pdp.EffectDeny:
+		ah.action = policy.TypeBlock
+
+		i := 0
+		for i < oCount {
+			o := r.Obligations[i]
+
+			id := o.GetID()
+			switch id {
+			default:
+				if t, ok := custAttrs[id]; ok && t.isEdns() {
+					ah.putCustomAttr(o, t)
+
+					oCount--
+					r.Obligations[i] = r.Obligations[oCount]
+					continue
+				}
+
+			case attrNameRefuse:
+				ah.action = policy.TypeRefuse
+
+			case attrNameDrop:
+				ah.action = policy.TypeDrop
+			}
+
+			i++
+		}
+	}
+
+	ah.dnRes = r.Obligations[:oCount]
+}
+
+
+func (ah *attrHolder) putCustomAttr(attr pdp.AttributeAssignment, f custAttr) {
+	if f.isEdns() {
+		id := attr.GetID()
+
+		for _, a := range ah.dnReq[ednsAttrsStart:] {
+			if id == a.GetID() {
+				return
+			}
+		}
+
+		ah.dnReq = append(ah.dnReq, attr)
+	}
+
+	if f.isTransfer() {
+		ah.transfer = append(ah.transfer, attr)
+	}
+
+	if f.isDnstap() {
+		ah.dnstap = append(ah.dnstap, attr)
+	}
+}
+
+func (ah *attrHolder) prepareResponseFromContext(ctx context.Context, xtr *rq.Extractor) {
+	ipResp, _ := xtr.Value("response_ip")
+	if ipResp != "" {
+		ip := net.ParseIP(ipResp)
+		if ip != nil {
+			ah.addIPReq(ip)
+		}
+	}
+}
+
+func (ah *attrHolder) addIPReq(ip net.IP) {
+	ah.ipReq = append(
+		[]pdp.AttributeAssignment{
+			pdp.MakeStringAssignment(attrNameType, typeValueResponse),
+			pdp.MakeAddressAssignment(attrNameAddress, ip),
+		},
+		ah.transfer...,
+	)
+}
+
+func (ah *attrHolder) addIPRes(r *pdp.Response) {
+	switch r.Effect {
+	default:
+		log.Printf("[ERROR] PDP Effect: %s, Reason: %s", pdp.EffectNameFromEnum(r.Effect), r.Status)
+		ah.action = policy.TypeNone
+
+	case pdp.EffectPermit:
+		ah.action = policy.TypeAllow
+
+		//for _, o := range r.Obligations {
+		//	if o.GetID() == attrNameLog {
+		//		ah.action = firewall.TypeLog
+		//		break
+		//	}
+		//}
+
+	case pdp.EffectDeny:
+		ah.action = policy.TypeBlock
+
+		for _, o := range r.Obligations {
+			switch o.GetID() {
+			case attrNameRefuse:
+				ah.action = policy.TypeRefuse
+
+			//case attrNameRedirectTo:
+			//	ah.addRedirect(o)
+
+			case attrNameDrop:
+				ah.action = policy.TypeDrop
+			}
+		}
+	}
+
+	ah.ipRes = r.Obligations
+}

--- a/plugin/themis/attrholder_test.go
+++ b/plugin/themis/attrholder_test.go
@@ -1,0 +1,829 @@
+package themisplugin
+
+import (
+	"fmt"
+	"github.com/coredns/policy/plugin/firewall/policy"
+	"github.com/coredns/policy/plugin/pkg/rqdata"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/infobloxopen/go-trees/domain"
+	"github.com/miekg/dns"
+	"github.com/coredns/coredns/request"
+
+	"context"
+
+	"github.com/coredns/coredns/plugin/metadata"
+	"github.com/infobloxopen/themis/pdp"
+)
+
+type fakeWriter struct {
+	dns.ResponseWriter
+	clientIP string
+	serverIP string
+}
+
+func (w *fakeWriter) LocalAddr() net.Addr {
+	local := net.ParseIP(w.clientIP)
+	return &net.UDPAddr{IP: local, Port: 53} // Port is not used here
+}
+
+func (w *fakeWriter) RemoteAddr() net.Addr {
+	remote := net.ParseIP(w.serverIP)
+	return &net.UDPAddr{IP: remote, Port: 53} // Port is not used here
+}
+
+func buildFunc(v string) metadata.Func {
+	return func() string { return v }
+}
+func buildContext(ctx context.Context, data map[string]string) context.Context {
+//	ctx = metadata.ForMetadata(ctx)
+	for k, v := range data {
+		metadata.SetValueFunc(ctx, k, buildFunc(v))
+	}
+	return ctx
+}
+
+func buildState(name string, qtype uint16, clientIp string) request.Request {
+	//create a msg
+	req := new(dns.Msg)
+	req.SetQuestion(name, qtype)
+	return request.Request{Req:req, W:&fakeWriter{clientIP:clientIp}}
+}
+
+func TestNewAttrHolderWithDnReq(t *testing.T) {
+	optsMap := []*attrSetting{
+		{"low", "request/low", "String", false},
+		{"high", "request/high", "String", false},
+		{"byte", "request/byte", "String", false},
+		{attrNameSourceIP, "request/source_ip", "Address", false},
+	}
+
+	mapping := rqdata.NewMapping("")
+	state := buildState("example.com.", dns.TypeA, "192.0.2.1")
+	mdata := map[string]string{
+		"request/source_ip":            "2001:db8::1",
+		"request/low":                  "0001020304050607",
+		"request/high":                 "08090a0b0c0d0e0f",
+		"request/byte":                 "test",
+	}
+
+	ctx := context.TODO()
+	ctx = buildContext(ctx, mdata)
+
+	ah := newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping), optsMap, nil)
+	pdp.AssertAttributeAssignments(t, "newAttrHolderWithDnReq", ah.dnReq,
+		pdp.MakeStringAssignment(attrNameType, typeValueQuery),
+		pdp.MakeDomainAssignment(attrNameDomainName, makeTestDomain(dns.Fqdn("example.com"))),
+		pdp.MakeStringAssignment(attrNameDNSQtype, strconv.FormatUint(uint64(dns.TypeA), 16)),
+		pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("2001:db8::1")),
+		pdp.MakeStringAssignment("low", "0001020304050607"),
+		pdp.MakeStringAssignment("high", "08090a0b0c0d0e0f"),
+		pdp.MakeStringAssignment("byte", "test"),
+	)
+
+	state = buildState("example.com.", dns.TypeA, "example.com:53")
+	mdata = map[string]string{
+		"request/source_ip":            "2001:db8::1",
+		"request/low":                  "0001020304050607",
+		"request/high":                 "08090a0b0c0d0e0f",
+		"request/byte":                 "test",
+	}
+
+	ctx = buildContext(context.TODO(), mdata)
+	ah = newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping), optsMap, nil)
+	pdp.AssertAttributeAssignments(t, "newAttrHolderWithDnReq(notIPRemoteAddr)", ah.dnReq,
+		pdp.MakeStringAssignment(attrNameType, typeValueQuery),
+		pdp.MakeDomainAssignment(attrNameDomainName, makeTestDomain(dns.Fqdn("example.com"))),
+		pdp.MakeStringAssignment(attrNameDNSQtype, strconv.FormatUint(uint64(dns.TypeA), 16)),
+		pdp.MakeStringAssignment("low", "0001020304050607"),
+		pdp.MakeStringAssignment("high", "08090a0b0c0d0e0f"),
+		pdp.MakeStringAssignment("byte", "test"),
+		pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("2001:db8::1")),
+	)
+
+	state = buildState("...", dns.TypeA, "example.com:53")
+	ctx = buildContext(context.TODO(), mdata)
+	assertPanicWithError(t, "newAttrHolderWithDnReq(invalidDomainName)", func() {
+		newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping), optsMap, nil)
+	}, "Can't treat %q as domain name: %s", "...", domain.ErrEmptyLabel)
+}
+
+func TestAddIpReq(t *testing.T) {
+
+	optsMap := []*attrSetting{
+		{attrNameSourceIP, "request/source_ip", "Address", false},
+	}
+	mdata := map[string]string{}
+	mapping := rqdata.NewMapping("")
+	state := buildState("example.com.", dns.TypeA, "192.0.2.1")
+
+	ctx := buildContext(context.TODO(), mdata)
+
+	custAttrs := map[string]custAttr{
+		"trans": custAttrTransfer,
+	}
+
+	ah := newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping),optsMap, nil)
+	pdp.AssertAttributeAssignments(t, "newAttrHolderWithDnReq - dnReq", ah.dnReq,
+		pdp.MakeStringAssignment(attrNameType, typeValueQuery),
+		pdp.MakeDomainAssignment(attrNameDomainName, makeTestDomain(dns.Fqdn("example.com"))),
+		pdp.MakeStringAssignment(attrNameDNSQtype, strconv.FormatUint(uint64(dns.TypeA), 16)),
+		pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.1")),
+	)
+	pdp.AssertAttributeAssignments(t, "newAttrHolderWithDnReq - dnRes", ah.dnRes)
+
+	ah.addDnRes(
+		&pdp.Response{
+			Effect: pdp.EffectPermit,
+			Obligations: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("trans", "val"),
+			},
+		},
+		custAttrs,
+	)
+	pdp.AssertAttributeAssignments(t, "addDnRes - dnRes", ah.dnRes,
+		pdp.MakeStringAssignment("trans", "val"),
+	)
+	pdp.AssertAttributeAssignments(t, "addDnRes - transfer", ah.transfer,
+		pdp.MakeStringAssignment("trans", "val"),
+	)
+
+	ah.addIPReq(net.ParseIP("2001:db8::1"))
+	pdp.AssertAttributeAssignments(t, "addIPReq - ipReq", ah.ipReq,
+		pdp.MakeStringAssignment(attrNameType, typeValueResponse),
+		pdp.MakeAddressAssignment(attrNameAddress, net.ParseIP("2001:db8::1")),
+		pdp.MakeStringAssignment("trans", "val"),
+	)
+}
+
+func TestActionDomainResponse(t *testing.T) {
+	tests := []struct {
+		res    *pdp.Response
+		action byte
+		dst    string
+	}{
+		{
+			res: &pdp.Response{
+				Effect: pdp.EffectPermit,
+			},
+			action: policy.TypeAllow,
+		},
+		{
+			res: &pdp.Response{
+				Effect: pdp.EffectIndeterminate,
+				Status: fmt.Errorf("example of pdp failure on domain validation"),
+			},
+			action: policy.TypeNone,
+		},
+		{
+			res: &pdp.Response{
+				Effect: pdp.EffectDeny,
+			},
+			action: policy.TypeBlock,
+		},
+		//{
+		//	res: &pdp.Response{
+		//		Effect: pdp.EffectDeny,
+		//		Obligations: []pdp.AttributeAssignment{
+		//			pdp.MakeStringAssignment(attrNameRedirectTo, "192.0.2.1"),
+		//		},
+		//	},
+		//	action: firewall.TypeRedirect,
+		//	dst:    "192.0.2.1",
+		//},
+		{
+			res: &pdp.Response{
+				Effect: pdp.EffectDeny,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeIntegerAssignment(attrNameRedirectTo, 0),
+				},
+			},
+			action: policy.TypeNone,
+		},
+		{
+			res: &pdp.Response{
+				Effect: pdp.EffectDeny,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeBooleanAssignment(attrNameRefuse, true),
+				},
+			},
+			action: policy.TypeRefuse,
+		},
+		//{
+		//	res: &pdp.Response{
+		//		Effect: pdp.EffectPermit,
+		//		Obligations: []pdp.AttributeAssignment{
+		//			pdp.MakeBooleanAssignment(attrNameLog, true),
+		//		},
+		//	},
+		//	action: firewall.TypeLog,
+		//},
+		{
+			res: &pdp.Response{
+				Effect: pdp.EffectDeny,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeBooleanAssignment(attrNameDrop, true),
+				},
+			},
+			action: policy.TypeDrop,
+		},
+	}
+
+	mdata := map[string]string{}
+	mapping := rqdata.NewMapping("")
+	state := buildState("example.com.", dns.TypeA, "192.0.2.1")
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			optMap := make([]*attrSetting, 0)
+			ctx := buildContext(context.TODO(), mdata)
+			ah := newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping), optMap, nil)
+
+			g := newLogGrabber()
+			ah.addDnRes(test.res, nil)
+			logs := g.Release()
+
+			if ah.action != test.action {
+				t.Errorf("unexpected action in TC #%d: expected=%d, actual=%d", i, test.action, ah.action)
+				t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
+			}
+			if ah.dst != test.dst {
+				t.Errorf("unexpected redirect destination in TC #%d: expected=%q, actual=%q", i, test.dst, ah.dst)
+				t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
+			}
+		})
+	}
+}
+
+func TestActionIpResponse(t *testing.T) {
+	tests := []struct {
+		res        *pdp.Response
+		initAction byte
+		action     byte
+		dst        string
+	}{
+		{
+			res: &pdp.Response{
+				Effect: pdp.EffectPermit,
+			},
+			initAction: policy.TypeAllow,
+			action:     policy.TypeAllow,
+		},
+		//{
+		//	res: &pdp.Response{
+		//		Effect: pdp.EffectPermit,
+		//	},
+		//	initAction: policy.TypeLog,
+		//	action:     policy.TypeAllow,
+		//},
+		//{
+		//	res: &pdp.Response{
+		//		Effect: pdp.EffectPermit,
+		//		Obligations: []pdp.AttributeAssignment{
+		//			pdp.MakeBooleanAssignment(attrNameLog, true),
+		//		},
+		//	},
+		//	initAction: policy.TypeAllow,
+		//	action:     policy.TypeLog,
+		//},
+		{
+			res: &pdp.Response{
+				Effect: pdp.EffectDeny,
+			},
+			initAction: policy.TypeAllow,
+			action:     policy.TypeBlock,
+		},
+		//{
+		//	res: &pdp.Response{
+		//		Effect: pdp.EffectDeny,
+		//		Obligations: []pdp.AttributeAssignment{
+		//			pdp.MakeStringAssignment(attrNameRedirectTo, "192.0.2.1"),
+		//		},
+		//	},
+		//	initAction: policy.TypeAllow,
+		//	action:     policy.TypeRedirect,
+		//	dst:        "192.0.2.1",
+		//},
+		{
+			res: &pdp.Response{
+				Effect: pdp.EffectDeny,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeBooleanAssignment(attrNameRefuse, true),
+				},
+			},
+			initAction: policy.TypeAllow,
+			action:     policy.TypeRefuse,
+		},
+		{
+			res: &pdp.Response{
+				Effect: pdp.EffectDeny,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeBooleanAssignment(attrNameDrop, true),
+				},
+			},
+			initAction: policy.TypeAllow,
+			action:     policy.TypeDrop,
+		},
+		{
+			res: &pdp.Response{
+				Effect: pdp.EffectIndeterminate,
+				Status: fmt.Errorf("example of pdp failure on IP validation"),
+			},
+			initAction: policy.TypeAllow,
+			action:     policy.TypeNone,
+		},
+	}
+	mdata := map[string]string{}
+	mapping := rqdata.NewMapping("")
+	state := buildState("example.com.", dns.TypeA, "192.0.2.1")
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			optMap := make([]*attrSetting, 0)
+			ctx := buildContext(context.TODO(), mdata)
+			ah := newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping), optMap, nil)
+
+			ah.action = test.initAction
+
+			g := newLogGrabber()
+			ah.addIPRes(test.res)
+			logs := g.Release()
+
+			if ah.action != test.action {
+				t.Errorf("unexpected action in TC #%d: expected=%d, actual=%d", i, test.action, ah.action)
+				t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
+			}
+			if ah.dst != test.dst {
+				t.Errorf("unexpected redirect destination in TC #%d: expected=%q, actual=%q", i, test.dst, ah.dst)
+				t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
+			}
+		})
+	}
+}
+
+func TestAddResponse(t *testing.T) {
+	mdata := map[string]string{
+		"request/edns1":                "edns1Val",
+	}
+	mapping := rqdata.NewMapping("")
+	state := buildState("example.com.", dns.TypeA, "192.0.2.1")
+
+	optsMap := []*attrSetting{
+		{"edns1", "request/edns1", "String", false},
+	}
+
+	custAttrs := map[string]custAttr{
+		"edns1":       custAttrEdns,
+		"trans1":      custAttrTransfer,
+		"transdnstap": custAttrTransfer | custAttrDnstap,
+		"dnstap":      custAttrDnstap,
+	}
+
+	tests := []struct {
+		opts   []*attrSetting
+		resp   *pdp.Response
+		dnRes  []pdp.AttributeAssignment
+		ipRes  []pdp.AttributeAssignment
+		edns0  []pdp.AttributeAssignment
+		trans  []pdp.AttributeAssignment
+		dnstap []pdp.AttributeAssignment
+	}{
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+			},
+			dnRes: []pdp.AttributeAssignment{},
+			ipRes: []pdp.AttributeAssignment{},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.1")),
+			},
+			trans:  []pdp.AttributeAssignment{},
+			dnstap: []pdp.AttributeAssignment{},
+		},
+		{
+			opts: optsMap,
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+			},
+			dnRes: []pdp.AttributeAssignment{},
+			ipRes: []pdp.AttributeAssignment{},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.2")),
+				pdp.MakeStringAssignment("edns1", "edns1Val"),
+			},
+			trans: []pdp.AttributeAssignment{},
+		},
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("edns1", "edns1Val"),
+				},
+			},
+			dnRes: []pdp.AttributeAssignment{},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.3")),
+				pdp.MakeStringAssignment("edns1", "edns1Val"),
+			},
+			trans: []pdp.AttributeAssignment{},
+		},
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectDeny,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("edns1", "edns1Val"),
+				},
+			},
+			dnRes: []pdp.AttributeAssignment{},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.4")),
+				pdp.MakeStringAssignment("edns1", "edns1Val"),
+			},
+			trans: []pdp.AttributeAssignment{},
+		},
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("edns1", "edns1Val"),
+				},
+			},
+			ipRes: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("edns1", "edns1Val"),
+			},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.5")),
+			},
+			trans: []pdp.AttributeAssignment{},
+		},
+		{
+			opts: optsMap,
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("edns1", "edns1Val2"),
+				},
+			},
+			dnRes: []pdp.AttributeAssignment{},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.6")),
+				pdp.MakeStringAssignment("edns1", "edns1Val"),
+			},
+			trans: []pdp.AttributeAssignment{},
+		},
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("edns1", "edns1Val2"),
+				},
+			},
+			dnRes: []pdp.AttributeAssignment{},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.7")),
+				pdp.MakeStringAssignment("edns1", "edns1Val2"),
+			},
+			trans: []pdp.AttributeAssignment{},
+		},
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("trans1", "trans1Val1"),
+				},
+			},
+			ipRes: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("trans1", "trans1Val1"),
+			},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.8")),
+			},
+			trans: []pdp.AttributeAssignment{},
+		},
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("trans1", "trans1Val1"),
+				},
+			},
+			dnRes: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("trans1", "trans1Val1"),
+			},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.9")),
+			},
+			trans: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("trans1", "trans1Val1"),
+			},
+		},
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectDeny,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("trans1", "trans1Val1"),
+				},
+			},
+			dnRes: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("trans1", "trans1Val1"),
+			},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.10")),
+			},
+			trans: []pdp.AttributeAssignment{},
+		},
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("edns1", "ends1Val"),
+					pdp.MakeStringAssignment("trans1", "trans1Val1"),
+					pdp.MakeStringAssignment("other1", "other1Val1"),
+				},
+			},
+			dnRes: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("other1", "other1Val1"),
+				pdp.MakeStringAssignment("trans1", "trans1Val1"),
+			},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.11")),
+				pdp.MakeStringAssignment("edns1", "ends1Val"),
+			},
+			trans: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("trans1", "trans1Val1"),
+			},
+		},
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("edns1", "ends1Val"),
+					pdp.MakeStringAssignment("trans1", "trans1Val1"),
+					pdp.MakeStringAssignment("other1", "other1Val1"),
+				},
+			},
+			ipRes: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("edns1", "ends1Val"),
+				pdp.MakeStringAssignment("trans1", "trans1Val1"),
+				pdp.MakeStringAssignment("other1", "other1Val1"),
+			},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.12")),
+			},
+			trans: []pdp.AttributeAssignment{},
+		},
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("edns1", "ends1Val"),
+					pdp.MakeStringAssignment("trans1", "trans1Val1"),
+					pdp.MakeStringAssignment("other1", "other1Val1"),
+					pdp.MakeStringAssignment("transdnstap", "val"),
+				},
+			},
+			dnRes: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("transdnstap", "val"),
+				pdp.MakeStringAssignment("trans1", "trans1Val1"),
+				pdp.MakeStringAssignment("other1", "other1Val1"),
+			},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.13")),
+				pdp.MakeStringAssignment("edns1", "ends1Val"),
+			},
+			trans: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("transdnstap", "val"),
+				pdp.MakeStringAssignment("trans1", "trans1Val1"),
+			},
+			dnstap: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("transdnstap", "val"),
+			},
+		},
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("edns1", "ends1Val"),
+					pdp.MakeStringAssignment("trans1", "trans1Val1"),
+					pdp.MakeStringAssignment("other1", "other1Val1"),
+					pdp.MakeStringAssignment("transdnstap", "val"),
+				},
+			},
+			ipRes: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("edns1", "ends1Val"),
+				pdp.MakeStringAssignment("trans1", "trans1Val1"),
+				pdp.MakeStringAssignment("other1", "other1Val1"),
+				pdp.MakeStringAssignment("transdnstap", "val"),
+			},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.14")),
+			},
+			trans:  []pdp.AttributeAssignment{},
+			dnstap: []pdp.AttributeAssignment{},
+		},
+		{
+			resp: &pdp.Response{
+				Effect: pdp.EffectPermit,
+				Obligations: []pdp.AttributeAssignment{
+					pdp.MakeStringAssignment("other1", "other1Val1"),
+					pdp.MakeStringAssignment("dnstap", "val"),
+				},
+			},
+			dnRes: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("other1", "other1Val1"),
+				pdp.MakeStringAssignment("dnstap", "val"),
+			},
+			edns0: []pdp.AttributeAssignment{
+				pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.15")),
+			},
+			trans: []pdp.AttributeAssignment{},
+			dnstap: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("dnstap", "val"),
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			state = buildState("example.com.", dns.TypeA, fmt.Sprintf("192.0.2.%d", i+1))
+			if test.dnRes != nil {
+
+				optMap := make([]*attrSetting, 0)
+				if test.opts != nil {
+					optMap = test.opts
+				}
+				ctx := buildContext(context.TODO(), mdata)
+				ah := newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping),optMap, nil)
+
+				ah.addDnRes(test.resp, custAttrs)
+
+				pdp.AssertAttributeAssignments(t,
+					fmt.Sprintf("TestAddResponse test %d dnRes", i+1),
+					ah.dnRes, test.dnRes...,
+				)
+				if test.edns0 != nil {
+					pdp.AssertAttributeAssignments(t,
+						fmt.Sprintf("TestAddResponse test %d (dnRes) - edns0", i+1),
+						ah.dnReq[ednsAttrsStart:], test.edns0...,
+					)
+				}
+				if test.trans != nil {
+					pdp.AssertAttributeAssignments(t,
+						fmt.Sprintf("TestAddResponse test %d (dnRes) - trans", i+1),
+						ah.transfer, test.trans...,
+					)
+				}
+				if test.dnstap != nil {
+					pdp.AssertAttributeAssignments(t,
+						fmt.Sprintf("TestAddResponse test %d (dnRes) - dnstap", i+1),
+						ah.dnstap, test.dnstap...,
+					)
+				}
+			}
+
+			if test.ipRes != nil {
+				optMap := make([]*attrSetting, 0)
+				if test.opts != nil {
+					optMap = test.opts
+				}
+				ctx := buildContext(context.TODO(), mdata)
+				ah := newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping),optMap, nil)
+				ah.addIPRes(test.resp)
+
+				pdp.AssertAttributeAssignments(t,
+					fmt.Sprintf("TestAddResponse test %d ipRes", i+1),
+					ah.dnRes, test.dnRes...,
+				)
+				if test.edns0 != nil {
+					pdp.AssertAttributeAssignments(t,
+						fmt.Sprintf("TestAddResponse test %d (ipRes) - edns0", i+1),
+						ah.dnReq[ednsAttrsStart:], test.edns0...,
+					)
+				}
+				if test.trans != nil {
+					pdp.AssertAttributeAssignments(t,
+						fmt.Sprintf("TestAddResponse test %d (ipRes) - trans", i+1),
+						ah.transfer, test.trans...,
+					)
+				}
+				if test.dnstap != nil {
+					pdp.AssertAttributeAssignments(t,
+						fmt.Sprintf("TestAddResponse test %d (ipRes) - dnstap", i+1),
+						ah.dnstap, test.dnstap...,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestMakeDnstapReport(t *testing.T) {
+
+	mdata := map[string]string{
+		"request/edns1":                "edns1Val",
+	}
+	mapping := rqdata.NewMapping("")
+	state := buildState("example.com.", dns.TypeA, "192.0.2.1")
+
+	optsMap := []*attrSetting{
+		{"edns", "request/edns", "String", false},
+	}
+
+	custAttrs := map[string]custAttr{
+		"edns":   custAttrEdns,
+		"trans":  custAttrTransfer,
+		"dnstap": custAttrDnstap,
+	}
+
+	ctx := buildContext(context.TODO(), mdata)
+	ah := newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping), optsMap, nil)
+	pdp.AssertAttributeAssignments(t, "newAttrHolderWithDnReq - dnReq", ah.dnReq,
+		pdp.MakeStringAssignment(attrNameType, typeValueQuery),
+		pdp.MakeDomainAssignment(attrNameDomainName, makeTestDomain(dns.Fqdn("example.com"))),
+		pdp.MakeStringAssignment(attrNameDNSQtype, strconv.FormatUint(uint64(dns.TypeA), 16)),
+		pdp.MakeAddressAssignment(attrNameSourceIP, net.ParseIP("192.0.2.1")),
+		pdp.MakeStringAssignment("edns", "ednsVal"),
+	)
+	pdp.AssertAttributeAssignments(t, "newAttrHolderWithDnReq - dnRes", ah.dnRes)
+
+	ah.addDnRes(
+		&pdp.Response{
+			Effect: pdp.EffectPermit,
+			Obligations: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("trans", "transVal"),
+				pdp.MakeStringAssignment("dnstap", "dnstapVal"),
+			},
+		},
+		custAttrs,
+	)
+	pdp.AssertAttributeAssignments(t, "addDnRes - dnRes", ah.dnRes,
+		pdp.MakeStringAssignment("trans", "transVal"),
+		pdp.MakeStringAssignment("dnstap", "dnstapVal"),
+	)
+	pdp.AssertAttributeAssignments(t, "addDnRes - transfer", ah.transfer,
+		pdp.MakeStringAssignment("trans", "transVal"),
+	)
+	pdp.AssertAttributeAssignments(t, "addDnRes - dnstap", ah.dnstap,
+		pdp.MakeStringAssignment("dnstap", "dnstapVal"),
+	)
+
+	ah.addIPReq(net.ParseIP("2001:db8::1"))
+	pdp.AssertAttributeAssignments(t, "addIPReq - ipReq", ah.ipReq,
+		pdp.MakeStringAssignment(attrNameType, typeValueResponse),
+		pdp.MakeAddressAssignment(attrNameAddress, net.ParseIP("2001:db8::1")),
+		pdp.MakeStringAssignment("trans", "transVal"),
+	)
+
+	ah.addIPRes(
+		&pdp.Response{
+			Effect: pdp.EffectPermit,
+			Obligations: []pdp.AttributeAssignment{
+				pdp.MakeStringAssignment("other", "otherVal"),
+			},
+		},
+	)
+
+	pdp.AssertAttributeAssignments(t, "addIPRes - dnRes", ah.dnRes,
+		pdp.MakeStringAssignment("trans", "transVal"),
+		pdp.MakeStringAssignment("dnstap", "dnstapVal"),
+	)
+	pdp.AssertAttributeAssignments(t, "addIPRes - ipRes", ah.ipRes,
+		pdp.MakeStringAssignment("other", "otherVal"),
+	)
+	pdp.AssertAttributeAssignments(t, "addIPRes - transfer", ah.transfer,
+		pdp.MakeStringAssignment("trans", "transVal"),
+	)
+	pdp.AssertAttributeAssignments(t, "addIPRes - dnstap", ah.dnstap,
+		pdp.MakeStringAssignment("dnstap", "dnstapVal"),
+	)
+
+}
+
+func makeTestDomain(s string) domain.Name {
+	dn, err := domain.MakeNameFromString(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return dn
+}
+
+func assertPanicWithError(t *testing.T, desc string, f func(), format string, args ...interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			e := fmt.Sprintf(format, args...)
+			err, ok := r.(error)
+			if !ok {
+				t.Errorf("excpected error %q on panic for %q but got %T (%#v)", e, desc, r, r)
+			} else if err.Error() != e {
+				t.Errorf("excpected error %q on panic for %q but got %q", e, desc, r)
+			}
+		} else {
+			t.Errorf("expected panic %q for %q", fmt.Sprintf(format, args...), desc)
+		}
+	}()
+
+	f()
+}

--- a/plugin/themis/attributes.go
+++ b/plugin/themis/attributes.go
@@ -1,0 +1,61 @@
+package themisplugin
+
+import "github.com/infobloxopen/themis/pdp"
+
+const (
+	attrNameType         = "type"
+	attrNameDomainName   = "domain_name"
+	attrNameDNSQtype     = "dns_qtype"
+	attrNameSourceIP     = "source_ip"
+	attrNameAddress      = "address"
+	attrNameLog          = "log"
+	attrNameRedirectTo   = "redirect_to"
+	attrNameRefuse       = "refuse"
+	attrNameDrop         = "drop"
+	attrNamePolicyAction = "policy_action"
+
+	typeValueQuery    = "query"
+	typeValueResponse = "response"
+
+	ednsAttrsStart = 3
+	ipReqAddrPos   = 1
+)
+
+func serializeOrPanic(a pdp.AttributeAssignment) string {
+	v, err := a.GetValue()
+	if err != nil {
+		panic(err)
+	}
+
+	s, err := v.Serialize()
+	if err != nil {
+		panic(err)
+	}
+
+	return s
+}
+
+type custAttr byte
+
+const (
+	custAttrEdns = 1 << iota
+	custAttrTransfer
+	custAttrDnstap
+	custAttrMetrics
+)
+
+func (a custAttr) isEdns() bool {
+	return a&custAttrEdns != 0
+}
+
+func (a custAttr) isTransfer() bool {
+	return a&custAttrTransfer != 0
+}
+
+func (a custAttr) isDnstap() bool {
+	return a&custAttrDnstap != 0
+}
+
+func (a custAttr) isMetrics() bool {
+	return a&custAttrMetrics != 0
+}

--- a/plugin/themis/attributes_test.go
+++ b/plugin/themis/attributes_test.go
@@ -1,0 +1,54 @@
+package themisplugin
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/infobloxopen/themis/pdp"
+)
+
+func TestSerializeOrPanic(t *testing.T) {
+	s := serializeOrPanic(pdp.MakeStringAssignment("s", "test"))
+	if s != "test" {
+		t.Errorf("expected %q but got %q", "test", s)
+	}
+
+	assertPanicWithErrorContains(t, "serializeOrPanic(expression)", func() {
+		serializeOrPanic(pdp.MakeExpressionAssignment("s", pdp.MakeStringDesignator("s")))
+	}, "pdp.AttributeDesignator")
+
+	assertPanicWithErrorContains(t, "serializeOrPanic(undefined)", func() {
+		serializeOrPanic(pdp.MakeExpressionAssignment("s", pdp.UndefinedValue))
+	}, "Undefined")
+}
+
+func TestCustAttr(t *testing.T) {
+	if !custAttr(custAttrEdns).isEdns() {
+		t.Errorf("expected %d is EDNS", custAttrEdns)
+	}
+
+	if !custAttr(custAttrTransfer).isTransfer() {
+		t.Errorf("expected %d is transfer", custAttrTransfer)
+	}
+
+	if !custAttr(custAttrDnstap).isDnstap() {
+		t.Errorf("expected %d is DNStap", custAttrDnstap)
+	}
+}
+
+func assertPanicWithErrorContains(t *testing.T, desc string, f func(), e string) {
+	defer func() {
+		if r := recover(); r != nil {
+			err, ok := r.(error)
+			if !ok {
+				t.Errorf("excpected error containing %q on panic for %q but got %T (%#v)", e, desc, r, r)
+			} else if !strings.Contains(err.Error(), e) {
+				t.Errorf("excpected error containing %q on panic for %q but got %q", e, desc, r)
+			}
+		} else {
+			t.Errorf("expected error containing %q on panic for %q", e, desc)
+		}
+	}()
+
+	f()
+}

--- a/plugin/themis/client.go
+++ b/plugin/themis/client.go
@@ -1,0 +1,155 @@
+package themisplugin
+
+import (
+	"log"
+	"sync/atomic"
+
+	//"github.com/coredns/coredns/plugin/pkg/trace"
+	"github.com/infobloxopen/coredns-themis/client"
+	"github.com/infobloxopen/themis/pdp"
+	"github.com/infobloxopen/themis/pep"
+)
+
+// connect establishes connection to PDP server.
+func (p *ThemisEngine) connect() error {
+	log.Printf("[DEBUG] Connecting %v", p)
+
+	for _, addr := range p.conf.endpoints {
+		p.connAttempts[addr] = new(uint32)
+	}
+
+	opts := []pep.Option{
+		pep.WithConnectionTimeout(p.conf.connTimeout),
+		pep.WithConnectionStateNotification(p.connStateCb),
+	}
+
+	if p.conf.cacheTTL > 0 {
+		if p.conf.cacheLimit > 0 {
+			opts = append(opts, pep.WithCacheTTLAndMaxSize(p.conf.cacheTTL, p.conf.cacheLimit))
+		} else {
+			opts = append(opts, pep.WithCacheTTL(p.conf.cacheTTL))
+		}
+	}
+
+	if p.conf.streams <= 0 || !p.conf.hotSpot {
+		opts = append(opts, pep.WithRoundRobinBalancer(p.conf.endpoints...))
+	}
+
+	if p.conf.streams > 0 {
+		opts = append(opts, pep.WithStreams(p.conf.streams))
+		if p.conf.hotSpot {
+			opts = append(opts, pep.WithHotSpotBalancer(p.conf.endpoints...))
+		}
+	}
+
+	opts = append(opts, pep.WithAutoRequestSize(p.conf.autoReqSize))
+	if p.conf.maxReqSize > 0 {
+		opts = append(opts, pep.WithMaxRequestSize(uint32(p.conf.maxReqSize)))
+	}
+
+	p.attrPool = makeAttrPool(p.conf.maxResAttrs, false)
+
+	//if p.trace != nil {
+	//	if t, ok := p.trace.(trace.Trace); ok {
+	//		opts = append(opts, pep.WithTracer(t.Tracer()))
+	//	}
+	//}
+
+	if p.conf.policyFile != "" {
+		p.pdp = client.NewBuiltinClient(p.conf.policyFile, p.conf.contentFiles)
+	} else {
+		p.pdp = pep.NewClient(opts...)
+	}
+
+	return p.pdp.Connect("")
+}
+
+// closeConn terminates previously established connection.
+func (p *ThemisEngine) closeConn() {
+	if p.pdp != nil {
+		go func() {
+			p.wg.Wait()
+			p.pdp.Close()
+		}()
+	}
+}
+
+func (p *ThemisEngine) validate(ah *attrHolder, a []pdp.AttributeAssignment) error {
+	var req []pdp.AttributeAssignment
+	if len(ah.ipReq) > 0 {
+		req = ah.ipReq
+	} else {
+		req = ah.dnReq
+	}
+
+	if p.conf.log {
+		log.Printf("[INFO] PDP request: %+v", req)
+	}
+
+	res := pdp.Response{Obligations: a}
+	err := p.pdp.Validate(req, &res)
+	if err != nil {
+		log.Printf("[ERROR] Policy validation failed due to error %s", err)
+		return err
+	}
+
+	if p.conf.log {
+		log.Printf("[INFO] PDP response: %+v", res)
+	}
+
+	if len(ah.ipReq) > 0 {
+		ah.addIPRes(&res)
+	} else {
+		ah.addDnRes(&res, p.conf.custAttrs)
+	}
+
+	return nil
+}
+
+func (p *ThemisEngine) connStateCb(addr string, state int, err error) {
+	switch state {
+	default:
+		if err != nil {
+			log.Printf("[DEBUG] Unknown connection notification %s (%s)", addr, err)
+		} else {
+			log.Printf("[DEBUG] Unknown connection notification %s", addr)
+		}
+
+	case pep.StreamingConnectionEstablished:
+		ptr, ok := p.connAttempts[addr]
+		if !ok {
+			ptr = p.unkConnAttempts
+		}
+		atomic.StoreUint32(ptr, 0)
+
+		log.Printf("[INFO] Connected to %s", addr)
+
+	case pep.StreamingConnectionBroken:
+		log.Printf("[ERROR] Connection to %s has been broken", addr)
+
+	case pep.StreamingConnectionConnecting:
+		ptr, ok := p.connAttempts[addr]
+		if !ok {
+			ptr = p.unkConnAttempts
+		}
+		count := atomic.AddUint32(ptr, 1)
+
+		if count <= 1 {
+			log.Printf("[INFO] Connecting to %s", addr)
+		}
+
+		if count > 100 {
+			log.Printf("[ERROR] Connecting to %s", addr)
+			atomic.StoreUint32(ptr, 1)
+		}
+
+	case pep.StreamingConnectionFailure:
+		ptr, ok := p.connAttempts[addr]
+		if !ok {
+			ptr = p.unkConnAttempts
+		}
+		if atomic.LoadUint32(ptr) <= 1 {
+			log.Printf("[ERROR] Failed to connect to %s (%s)", addr, err)
+		}
+	}
+}

--- a/plugin/themis/client/builtin_client.go
+++ b/plugin/themis/client/builtin_client.go
@@ -1,0 +1,155 @@
+package client
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/infobloxopen/themis/pdp"
+	"github.com/infobloxopen/themis/pdp/ast"
+	"github.com/infobloxopen/themis/pdp/jcon"
+	// the following is for initializing pdp local selector
+	_ "github.com/infobloxopen/themis/pdp/selector"
+)
+
+type builtinClient struct {
+	policyFile   string
+	contentFiles []string
+
+	parser ast.Parser
+
+	p *pdp.PolicyStorage
+	c *pdp.LocalContentStorage
+}
+
+func NewBuiltinClient(policyFile string, contentFiles []string) *builtinClient {
+	c := &builtinClient{
+		policyFile:   policyFile,
+		contentFiles: contentFiles,
+	}
+	return c
+}
+
+func (c *builtinClient) setPolicyParser() {
+	if c.policyFile != "" {
+		ext := filepath.Ext(c.policyFile)
+		switch ext {
+		case ".json":
+			c.parser = ast.NewJSONParser()
+		case ".yaml":
+			c.parser = ast.NewYAMLParser()
+		}
+	}
+}
+
+func (c *builtinClient) loadPolicies() error {
+	log.Printf("[INFO] Loading policy '%s'", c.policyFile)
+	c.setPolicyParser()
+
+	pf, err := os.Open(c.policyFile)
+	if err != nil {
+		log.Printf("[ERROR] Failed to open policy file: %s", err)
+		return err
+	}
+
+	log.Printf("[INFO] Parsing policy '%s'", c.policyFile)
+	p, err := c.parser.Unmarshal(pf, nil)
+	if err != nil {
+		log.Printf("[ERROR] Failed to parse policy: %s", err)
+		return err
+	}
+
+	c.p = p
+	return nil
+}
+
+func (c *builtinClient) loadContents() error {
+	log.Print("[INFO] Loading content")
+
+	var items []*pdp.LocalContent
+	for _, path := range c.contentFiles {
+		err := func() error {
+			log.Printf("[INFO] Opening content '%s'", path)
+			f, err := os.Open(path)
+			if err != nil {
+				log.Printf("[ERROR] Failed to open content: %s", err)
+				return err
+			}
+
+			defer f.Close()
+
+			log.Printf("[INFO] Parsing content '%s'", path)
+			item, err := jcon.Unmarshal(f, nil)
+			if err != nil {
+				log.Printf("[ERROR] Failed to parse content: %s", err)
+				return err
+			}
+
+			items = append(items, item)
+			return nil
+		}()
+		if err != nil {
+			return err
+		}
+	}
+
+	c.c = pdp.NewLocalContentStorage(items)
+	return nil
+}
+
+func (c *builtinClient) Connect(addr string) error {
+	if err := c.loadPolicies(); err != nil {
+		return err
+	}
+
+	if err := c.loadContents(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *builtinClient) Close() {
+	c.p = nil
+	c.c = nil
+}
+
+func (c *builtinClient) Validate(in, out interface{}) error {
+	req, ok := in.([]pdp.AttributeAssignment)
+	if !ok {
+		return fmt.Errorf("unknown request type passed to Validate()")
+	}
+	res, ok := out.(*pdp.Response)
+	if !ok {
+		return fmt.Errorf("unknown response type passed to Validate()")
+	}
+
+	ctx, err := pdp.NewContext(c.c, len(req), func(i int) (string, pdp.AttributeValue, error) {
+		id := req[i].GetID()
+		v, err := req[i].GetValue()
+		return id, v, err
+	})
+	if err != nil {
+		return fmt.Errorf("error creating pdp context '%s'", err)
+	}
+
+	r := c.p.Root().Calculate(ctx)
+
+	res.Effect = r.Effect
+	res.Status = r.Status
+	if res.Obligations == nil {
+		res.Obligations = r.Obligations
+	} else {
+		obLen := len(r.Obligations)
+		if obLen > len(res.Obligations) {
+			return fmt.Errorf("result obligations too small %d < %d",
+				len(res.Obligations), obLen)
+		}
+
+		copy(res.Obligations, r.Obligations)
+		res.Obligations = res.Obligations[:obLen]
+	}
+
+	return nil
+}

--- a/plugin/themis/client_test.go
+++ b/plugin/themis/client_test.go
@@ -1,0 +1,441 @@
+package themisplugin
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/coredns/policy/plugin/firewall/policy"
+	"github.com/coredns/policy/plugin/pkg/rqdata"
+	"github.com/miekg/dns"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"context"
+
+	"github.com/infobloxopen/themis/pdp"
+	_ "github.com/infobloxopen/themis/pdp/selector"
+	"github.com/infobloxopen/themis/pdpserver/server"
+)
+
+const testPolicy = `# Policy set for client interaction tests
+attributes:
+  type: string
+  domain_name: domain
+  address: address
+  rule: string
+  log: string
+  o1: string
+  o2: string
+  o3: string
+
+policies:
+  alg: FirstApplicableEffect
+  policies:
+  - id: "Query Policy"
+    target:
+    - equal:
+      - attr: type
+      - val:
+          type: string
+          content: query
+    alg: FirstApplicableEffect
+    rules:
+    - id: "Query for example.com"
+      target:
+      - contains:
+        - val:
+            type: set of domains
+            content:
+            - example.com
+        - attr: domain_name
+      effect: Permit
+      obligations:
+      - rule:
+          val:
+            type: string
+            content: "Query rule for example.com"
+    - id: "Many obligations rule"
+      target:
+      - contains:
+        - val:
+            type: set of domains
+            content:
+            - overflow.me
+        - attr: domain_name
+      effect: Permit
+      obligations:
+      - rule:
+          val:
+            type: string
+            content: "Many obligations rule"
+      - o1:
+          val:
+            type: string
+            content: "First additional obligation"
+      - o2:
+          val:
+            type: string
+            content: "Second additional obligation"
+      - o3:
+          val:
+            type: string
+            content: "Third additional obligation"
+  - id: "Response Policy"
+    target:
+    - equal:
+      - attr: type
+      - val:
+          type: string
+          content: response
+    alg: FirstApplicableEffect
+    rules:
+    - id: "Response for 192.0.2.0/28"
+      target:
+      - contains:
+        - val:
+            type: set of networks
+            content:
+            - 192.0.2.0/28
+        - attr: address
+      effect: Permit
+      obligations:
+      - rule:
+          val:
+            type: string
+            content: "Response rule for 192.0.2.0/28"
+      - log:
+          val:
+            type: string
+            content: ""
+`
+
+type logGrabber struct {
+	b *bytes.Buffer
+}
+
+func newLogGrabber() *logGrabber {
+	b := new(bytes.Buffer)
+	log.SetOutput(b)
+
+	return &logGrabber{
+		b: b,
+	}
+}
+
+func (g *logGrabber) Release() string {
+	log.SetOutput(os.Stderr)
+
+	return g.b.String()
+}
+
+func TestStreamingClientInteraction(t *testing.T) {
+	endpoint := "127.0.0.1:5555"
+	srv := startPDPServer(t, testPolicy, endpoint)
+	defer func() {
+		if logs := srv.Stop(); len(logs) > 0 {
+			t.Logf("server logs:\n%s", logs)
+		}
+	}()
+
+	if err := waitForPortOpened(endpoint); err != nil {
+		t.Fatalf("can't connect to PDP server: %s", err)
+	}
+
+	g := newLogGrabber()
+	ok := t.Run("noCache", func(t *testing.T) {
+		p := newThemisEngine()
+		p.conf.endpoints = []string{endpoint}
+		p.conf.connTimeout = time.Second
+		p.conf.streams = 1
+		p.conf.log = true
+
+		if err := p.connect(); err != nil {
+			t.Fatal(err)
+		}
+		defer p.closeConn()
+
+		mdata := map[string]string{}
+		mapping := rqdata.NewMapping("")
+		state := buildState("example.com.", dns.TypeA, "192.0.2.1")
+
+		ctx := buildContext(context.TODO(), mdata)
+
+		ah := newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping), p.conf.options, nil)
+
+		attrs := make([]pdp.AttributeAssignment, p.conf.maxResAttrs)
+		if err := p.validate(ah, attrs); err != nil {
+			t.Error(err)
+		}
+
+		if ah.action != policy.TypeAllow {
+			aName := fmt.Sprintf("unknown action %d", ah.action)
+			if ah.action >= 0 && int(ah.action) < len(policy.NameTypes) {
+				aName = policy.NameTypes[int(ah.action)]
+			}
+			t.Errorf("expected %q action but got %q", policy.NameTypes[policy.TypeAllow], aName)
+		}
+
+		pdp.AssertAttributeAssignments(t, "p.validate(domain request)", ah.dnRes,
+			pdp.MakeStringAssignment("rule", "Query rule for example.com"),
+		)
+
+		ah.addIPReq(net.ParseIP("192.0.2.1"))
+
+		attrs = make([]pdp.AttributeAssignment, p.conf.maxResAttrs)
+		if err := p.validate(ah, attrs); err != nil {
+			t.Error(err)
+		}
+
+		//if ah.action != policy.TypeLog {
+		//	aName := fmt.Sprintf("unknown action %d", ah.action)
+		//	if ah.action >= 0 && int(ah.action) < len(policy.NameTypes) {
+		//		aName = policy.NameTypes[int(ah.action)]
+		//	}
+		//	t.Errorf("expected %q action but got %q", policy.NameTypes[policy.TypeLog], aName)
+		//}
+
+		pdp.AssertAttributeAssignments(t, "p.validate(domain request)", ah.ipRes,
+			pdp.MakeStringAssignment("rule", "Response rule for 192.0.2.0/28"),
+			pdp.MakeStringAssignment("log", ""),
+		)
+	})
+
+	logs := g.Release()
+	if !ok {
+		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
+	}
+
+	g = newLogGrabber()
+	ok = t.Run("cacheTTL", func(t *testing.T) {
+		p := newThemisEngine()
+		p.conf.endpoints = []string{endpoint}
+		p.conf.connTimeout = time.Second
+		p.conf.streams = 1
+		p.conf.log = true
+		p.conf.maxReqSize = 128
+		p.conf.cacheTTL = 10 * time.Minute
+
+		if err := p.connect(); err != nil {
+			t.Fatal(err)
+		}
+		defer p.closeConn()
+
+		mdata := map[string]string{}
+		mapping := rqdata.NewMapping("")
+		state := buildState("example.com.", dns.TypeA, "192.0.2.1")
+
+		ctx := buildContext(context.TODO(), mdata)
+
+		ah := newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping), p.conf.options, nil)
+
+		attrs := make([]pdp.AttributeAssignment, p.conf.maxResAttrs)
+		if err := p.validate(ah, attrs); err != nil {
+			t.Error(err)
+		}
+
+		if ah.action != policy.TypeAllow {
+			aName := fmt.Sprintf("unknown action %d", ah.action)
+			if ah.action >= 0 && int(ah.action) < len(policy.NameTypes) {
+				aName = policy.NameTypes[int(ah.action)]
+			}
+			t.Errorf("expected %q action but got %q", policy.NameTypes[policy.TypeAllow], aName)
+		}
+
+		pdp.AssertAttributeAssignments(t, "p.validate(domain request)", ah.dnRes,
+			pdp.MakeStringAssignment("rule", "Query rule for example.com"),
+		)
+	})
+
+	logs = g.Release()
+	if !ok {
+		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
+	}
+
+	g = newLogGrabber()
+	ok = t.Run("cacheTTLAndLimit", func(t *testing.T) {
+		p := newThemisEngine()
+		p.conf.endpoints = []string{endpoint}
+		p.conf.connTimeout = time.Second
+		p.conf.streams = 1
+		p.conf.log = true
+		p.conf.maxReqSize = 128
+		p.conf.cacheTTL = 10 * time.Minute
+		p.conf.cacheLimit = 128
+
+		if err := p.connect(); err != nil {
+			t.Fatal(err)
+		}
+		defer p.closeConn()
+
+		mdata := map[string]string{}
+		mapping := rqdata.NewMapping("")
+		state := buildState("example.com.", dns.TypeA, "192.0.2.1")
+
+		ctx := buildContext(context.TODO(), mdata)
+
+		ah := newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping),p.conf.options, nil)
+		attrs := make([]pdp.AttributeAssignment, p.conf.maxResAttrs)
+		if err := p.validate(ah, attrs); err != nil {
+			t.Error(err)
+		}
+
+		if ah.action != policy.TypeAllow {
+			aName := fmt.Sprintf("unknown action %d", ah.action)
+			if ah.action >= 0 && int(ah.action) < len(policy.NameTypes) {
+				aName = policy.NameTypes[int(ah.action)]
+			}
+			t.Errorf("expected %q action but got %q", policy.NameTypes[policy.TypeAllow], aName)
+		}
+
+		pdp.AssertAttributeAssignments(t, "p.validate(domain request)", ah.dnRes,
+			pdp.MakeStringAssignment("rule", "Query rule for example.com"),
+		)
+	})
+
+	logs = g.Release()
+	if !ok {
+		t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
+	}
+}
+
+func TestStreamingClientInteractionWithObligationsOverflow(t *testing.T) {
+	endpoint := "127.0.0.1:5555"
+	srv := startPDPServer(t, testPolicy, endpoint)
+	defer func() {
+		if logs := srv.Stop(); len(logs) > 0 {
+			t.Logf("server logs:\n%s", logs)
+		}
+	}()
+
+	if err := waitForPortOpened(endpoint); err != nil {
+		t.Fatalf("can't connect to PDP server: %s", err)
+	}
+
+	ok := true
+	g := newLogGrabber()
+	defer func() {
+		logs := g.Release()
+		if !ok {
+			t.Logf("=== plugin logs ===\n%s--- plugin logs ---", logs)
+		}
+	}()
+
+	p := newThemisEngine()
+	p.conf.endpoints = []string{endpoint}
+	p.conf.connTimeout = time.Second
+	p.conf.streams = 1
+	p.conf.maxResAttrs = 3
+	p.conf.log = true
+
+	if err := p.connect(); err != nil {
+		t.Fatal(err)
+		ok = false
+	}
+	defer p.closeConn()
+
+	mdata := map[string]string{}
+	mapping := rqdata.NewMapping("")
+	state := buildState("example.com.", dns.TypeA, "192.0.2.1")
+
+	ctx := buildContext(context.TODO(), mdata)
+
+	ah := newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, mapping),p.conf.options, nil)
+	attrs := make([]pdp.AttributeAssignment, p.conf.maxResAttrs)
+	err := p.validate(ah, attrs)
+	if err == nil {
+		aName := fmt.Sprintf("unknown action %d", ah.action)
+		if ah.action >= 0 && int(ah.action) < len(policy.NameTypes) {
+			aName = policy.NameTypes[int(ah.action)]
+		}
+
+		t.Errorf("expected response overflow error but got %q response:\n:%+v", aName, ah.dnRes)
+		ok = false
+	}
+}
+
+func startPDPServer(t *testing.T, p, endpoint string) *loggedServer {
+	s := newServer(server.WithServiceAt(endpoint))
+
+	if err := s.s.ReadPolicies(strings.NewReader(p)); err != nil {
+		t.Fatalf("can't read policies: %s", err)
+	}
+
+	if err := waitForPortClosed(endpoint); err != nil {
+		t.Fatalf("port still in use: %s", err)
+	}
+
+	go func() {
+		if err := s.s.Serve(); err != nil {
+			t.Fatalf("PDP server failed: %s", err)
+		}
+	}()
+
+	return s
+}
+
+type loggedServer struct {
+	s *server.Server
+	b *bytes.Buffer
+}
+
+func newServer(opts ...server.Option) *loggedServer {
+	s := &loggedServer{
+		b: new(bytes.Buffer),
+	}
+
+	//logger := log.New()
+	//logger.Out = s.b
+	//logger.Level = log.ErrorLevel
+	//opts = append(opts,
+	//	server.WithLogger(logger),
+	//)
+
+	s.s = server.NewServer(opts...)
+	return s
+}
+
+func (s *loggedServer) Stop() string {
+	s.s.Stop()
+	return s.b.String()
+}
+
+func waitForPortOpened(address string) error {
+	var (
+		c   net.Conn
+		err error
+	)
+
+	for i := 0; i < 20; i++ {
+		after := time.After(500 * time.Millisecond)
+		c, err = net.DialTimeout("tcp", address, 500*time.Millisecond)
+		if err == nil {
+			return c.Close()
+		}
+
+		<-after
+	}
+
+	return err
+}
+
+func waitForPortClosed(address string) error {
+	var (
+		c   net.Conn
+		err error
+	)
+
+	for i := 0; i < 20; i++ {
+		after := time.After(500 * time.Millisecond)
+		c, err = net.DialTimeout("tcp", address, 500*time.Millisecond)
+		if err != nil {
+			return nil
+		}
+
+		c.Close()
+		<-after
+	}
+
+	return fmt.Errorf("port at %s hasn't been closed yet", address)
+}

--- a/plugin/themis/client_test.go
+++ b/plugin/themis/client_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/coredns/policy/plugin/pkg/rqdata"
 	"github.com/miekg/dns"
 	"net"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -117,7 +116,7 @@ type logGrabber struct {
 
 func newLogGrabber() *logGrabber {
 	b := new(bytes.Buffer)
-	log.SetOutput(b)
+	//log.SetOutput(b)
 
 	return &logGrabber{
 		b: b,
@@ -125,7 +124,7 @@ func newLogGrabber() *logGrabber {
 }
 
 func (g *logGrabber) Release() string {
-	log.SetOutput(os.Stderr)
+	//log.SetOutput(os.Stderr)
 
 	return g.b.String()
 }

--- a/plugin/themis/config.go
+++ b/plugin/themis/config.go
@@ -1,0 +1,349 @@
+package themisplugin
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mholt/caddy"
+)
+
+var errInvalidOption = errors.New("invalid themis plugin option")
+
+var allowedAttrTypes = map[string]string{
+	"string":  "string",
+	"domain":  "domain",
+	"address": "address"}
+
+type config struct {
+	policyFile   string
+	contentFiles []string
+	endpoints    []string
+	options      []*attrSetting
+	custAttrs    map[string]custAttr
+	debugID      string
+	debugSuffix  string
+	streams      int
+	hotSpot      bool
+	connTimeout  time.Duration
+	autoReqSize  bool
+	maxReqSize   int
+	autoResAttrs bool
+	maxResAttrs  int
+	log          bool
+	cacheTTL     time.Duration
+	cacheLimit   int
+}
+
+func themisParse(c *caddy.Controller) (*ThemisPlugin, error) {
+	tp := newThemisPlugin()
+	for c.Next() {
+		args := c.RemainingArgs()
+		if len(args) != 1 {
+			return nil, c.Errf("themis plugin should have the format : themis <EngineName> {...} ")
+		}
+		name := args[0]
+		if _, ok := tp.engines[name]; ok {
+			return nil, c.Errf("themis plugin with engine name %s is already declared", name)
+		}
+		p := newThemisEngine()
+		for c.NextBlock() {
+			if err := p.conf.parseOption(c); err != nil {
+				return nil, err
+			}
+		}
+		tp.engines[name] = p
+	}
+	return tp, nil
+}
+
+func (conf *config) parseOption(c *caddy.Controller) error {
+	switch c.Val() {
+	case "pdp":
+		return conf.parsePDP(c)
+
+	case "endpoint":
+		return conf.parseEndpoint(c)
+
+	case "attr":
+		return conf.parseAttr(c)
+
+	case "debug_query_suffix":
+		return conf.parseDebugQuerySuffix(c)
+
+	case "streams":
+		return conf.parseStreams(c)
+
+	case "transfer":
+		return conf.parseAttributes(c, custAttrTransfer)
+
+	case "metrics":
+		return conf.parseAttributes(c, custAttrMetrics)
+
+	case "debug_id":
+		return conf.parseDebugID(c)
+
+	case "connection_timeout":
+		return conf.parseConnectionTimeout(c)
+
+	case "log":
+		return conf.parseLog(c)
+
+	case "max_request_size":
+		return conf.parseMaxRequestSize(c)
+
+	case "max_response_attributes":
+		return conf.parseMaxResponseAttributes(c)
+
+	case "cache":
+		return conf.parseCache(c)
+	}
+
+	return errInvalidOption
+}
+
+// Usage: pdp policy.[yaml|json] content1 content2...
+func (conf *config) parsePDP(c *caddy.Controller) error {
+	args := c.RemainingArgs()
+	argsLen := len(args)
+	if argsLen < 1 {
+		return c.ArgErr()
+	}
+
+	conf.policyFile = args[0]
+	if argsLen > 1 {
+		conf.contentFiles = args[1:]
+	}
+	return nil
+}
+
+func (conf *config) parseEndpoint(c *caddy.Controller) error {
+	args := c.RemainingArgs()
+	if len(args) <= 0 {
+		return c.ArgErr()
+	}
+
+	conf.endpoints = args
+	return nil
+}
+
+func (conf *config) parseAttr(c *caddy.Controller) error {
+	args := c.RemainingArgs()
+	// Usage: edns0 <code> <name> [ <dataType> ] [ <size> <start> <end> ].
+	// Valid dataTypes are hex (default), bytes, ip.
+	// Valid destTypes depend on PDP (default string).
+	argsLen := len(args)
+	if argsLen != 2 && argsLen != 3 {
+		return c.Errf("Invalid attr directive. Expected 2 or 3 arguments but got %d", argsLen)
+	}
+
+	name := args[0]
+	label := args[1]
+	dataType := "string"
+	if argsLen > 2 {
+		dataType = args[2]
+	}
+
+	if _, ok := allowedAttrTypes[strings.ToLower(dataType)]; !ok {
+		tp := make([]string, 0)
+		for k := range allowedAttrTypes {
+			tp = append(tp, k)
+		}
+		return c.Errf("invalid type %s for an attribute - allowed types are : %s", dataType, strings.Join(tp, ","))
+	}
+	conf.options = append(conf.options, &attrSetting{name, label, dataType, false})
+	conf.custAttrs[name] = conf.custAttrs[name] | custAttrEdns
+	return nil
+}
+
+func (conf *config) parseAttributes(c *caddy.Controller, a custAttr) error {
+	args := c.RemainingArgs()
+	if len(args) <= 0 {
+		return c.ArgErr()
+	}
+
+	for _, item := range args {
+		conf.custAttrs[item] = conf.custAttrs[item] | a
+	}
+
+	return nil
+}
+
+func (conf *config) parseStreams(c *caddy.Controller) error {
+	args := c.RemainingArgs()
+	if len(args) < 1 || len(args) > 2 {
+		return c.ArgErr()
+	}
+
+	streams, err := strconv.ParseInt(args[0], 10, 32)
+	if err != nil {
+		return c.Errf("Could not parse number of streams: %s", err)
+	}
+	if streams < 1 {
+		return c.Errf("Expected at least one stream got %d", streams)
+	}
+
+	conf.streams = int(streams)
+
+	if len(args) > 1 {
+		switch strings.ToLower(args[1]) {
+		default:
+			return c.Errf("Expected round-robin or hot-spot balancing but got %s", args[1])
+
+		case "round-robin":
+			conf.hotSpot = false
+
+		case "hot-spot":
+			conf.hotSpot = true
+		}
+	} else {
+		conf.hotSpot = false
+	}
+
+	return nil
+}
+
+func (conf *config) parseDebugQuerySuffix(c *caddy.Controller) error {
+	args := c.RemainingArgs()
+	if len(args) != 1 {
+		return c.ArgErr()
+	}
+
+	conf.debugSuffix = args[0]
+	return nil
+}
+
+func (conf *config) parseDebugID(c *caddy.Controller) error {
+	args := c.RemainingArgs()
+	if len(args) != 1 {
+		return c.ArgErr()
+	}
+
+	conf.debugID = args[0]
+	return nil
+}
+
+func (conf *config) parseConnectionTimeout(c *caddy.Controller) error {
+	args := c.RemainingArgs()
+	if len(args) != 1 {
+		return c.ArgErr()
+	}
+
+	if strings.ToLower(args[0]) == "no" {
+		conf.connTimeout = -1
+	} else {
+		timeout, err := time.ParseDuration(args[0])
+		if err != nil {
+			return c.Errf("Could not parse timeout: %s", err)
+		}
+
+		conf.connTimeout = timeout
+	}
+
+	return nil
+}
+
+func (conf *config) parseLog(c *caddy.Controller) error {
+	args := c.RemainingArgs()
+	if len(args) != 0 {
+		return c.ArgErr()
+	}
+
+	conf.log = true
+	return nil
+}
+
+func (conf *config) parseMaxRequestSize(c *caddy.Controller) error {
+	args := c.RemainingArgs()
+	if len(args) < 1 || len(args) > 2 {
+		return c.ArgErr()
+	}
+
+	s := ""
+	if strings.ToLower(args[0]) == "auto" {
+		conf.autoReqSize = true
+		if len(args) > 1 {
+			s = args[1]
+		}
+	} else {
+		s = args[0]
+	}
+
+	if len(s) > 0 {
+		size, err := strconv.ParseUint(s, 10, 0)
+		if err != nil {
+			return c.Errf("Could not parse PDP request size limit: %s", err)
+		}
+
+		if size > math.MaxInt32 {
+			return c.Errf("Size limit %d (> %d) for PDP request is too high", size, math.MaxInt32)
+		}
+
+		conf.maxReqSize = int(size)
+	}
+
+	return nil
+}
+
+func (conf *config) parseMaxResponseAttributes(c *caddy.Controller) error {
+	args := c.RemainingArgs()
+	if len(args) != 1 {
+		return c.ArgErr()
+	}
+
+	if strings.ToLower(args[0]) == "auto" {
+		conf.autoResAttrs = true
+		return nil
+	}
+
+	n, err := strconv.ParseUint(args[0], 10, 0)
+	if err != nil {
+		return c.Errf("Could not parse PDP response attributes limit: %s", err)
+	}
+
+	if n > math.MaxInt32 {
+		return c.Errf("Attributes limit %d (> %d) for PDP response is too high", n, math.MaxInt32)
+	}
+
+	conf.maxResAttrs = int(n)
+	return nil
+}
+
+func (conf *config) parseCache(c *caddy.Controller) error {
+	args := c.RemainingArgs()
+	if len(args) > 2 {
+		return c.ArgErr()
+	}
+
+	if len(args) > 0 {
+		ttl, err := time.ParseDuration(args[0])
+		if err != nil {
+			return c.Errf("Could not parse decision cache TTL: %s", err)
+		}
+
+		if ttl <= 0 {
+			return c.Errf("Can't set decision cache TTL to %s", ttl)
+		}
+
+		conf.cacheTTL = ttl
+	} else {
+		conf.cacheTTL = 10 * time.Minute
+	}
+
+	if len(args) > 1 {
+		n, err := strconv.ParseUint(args[1], 10, 0)
+		if err != nil {
+			return c.Errf("Could not parse decision cache limit: %s", err)
+		}
+
+		if n > math.MaxInt32 {
+			return c.Errf("Cache limit %d (> %d) is too high", n, math.MaxInt32)
+		}
+
+		conf.cacheLimit = int(n)
+	}
+
+	return nil
+}

--- a/plugin/themis/config_test.go
+++ b/plugin/themis/config_test.go
@@ -1,0 +1,711 @@
+package themisplugin
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mholt/caddy"
+	"github.com/mholt/caddy/caddyfile"
+)
+
+func TestThemisConfigParse(t *testing.T) {
+	tests := []struct {
+		desc  string
+		input string
+		err   error
+
+		endpoints    []string
+		options      []*attrSetting
+		debugSuffix  *string
+		streams      *int
+		hotSpot      *bool
+		custAttrs    map[string]custAttr
+		debugID      *string
+		passthrough  []string
+		connTimeout  *time.Duration
+		autoReqSize  *bool
+		maxReqSize   *int
+		autoResAttrs *bool
+		maxResAttrs  *int
+		cacheTTL     *time.Duration
+		cacheLimit   *int
+	}{
+		{
+			desc: "InvalidOption",
+			input: `.:53 {
+						themis NAME {
+							error option
+						}
+					}`,
+			err: errors.New("invalid themis plugin option"),
+		},
+		{
+			desc: "NoEndpointArguemnts",
+			input: `.:53 {
+						themis NAME {
+							endpoint
+						}
+					}`,
+			err: errors.New("Wrong argument count or unexpected line ending"),
+		},
+		{
+			desc: "SingleEntryEndpoint",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+						}
+					}`,
+			endpoints: []string{"10.2.4.1:5555"},
+		},
+		{
+			desc: "ThreeEntriesEndpoint",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555 10.2.4.2:5555
+						}
+					}`,
+			endpoints: []string{"10.2.4.1:5555", "10.2.4.2:5555"},
+		},
+		{
+			desc: "InvalidAttrType",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							attr uid request/uid no-type
+						}
+					}`,
+			err: errors.New("invalid type"),
+		},
+		{
+			desc: "AttrCorrect",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							attr uid request/uid
+						}
+					}`,
+			options: []*attrSetting{
+				{"uid", "request/uid", "string", false},
+			},
+			custAttrs: map[string]custAttr{
+				"uid": custAttrEdns,
+			},
+		},
+		{
+			desc: "AttrCorrect2values",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							attr uid request/uid
+							attr ip request/ip address 
+						}
+					}`,
+			options: []*attrSetting{
+				{"uid", "request/uid", "string", false},
+				{"ip", "request/ip", "address", false},
+			},
+			custAttrs: map[string]custAttr{
+				"uid": custAttrEdns,
+				"ip":  custAttrEdns,
+			},
+		},
+		{
+			desc: "AttrWithNoLabel",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							attr my-name
+						}
+					}`,
+			err: errors.New("Invalid attr directive"),
+		},
+		{
+			desc: "NoDebugQuerySuffixArguments",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							debug_query_suffix
+						}
+					}`,
+			err: errors.New("Wrong argument count or unexpected line ending"),
+		},
+		{
+			desc: "DebugQuerySuffix",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							debug_query_suffix debug.local.
+						}
+					}`,
+			debugSuffix: newStringPtr("debug.local."),
+		},
+		{
+			desc: "PDPClientStreams",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							streams 10
+						}
+					}`,
+			streams: newIntPtr(10),
+		},
+		{
+			desc: "InvalidPDPClientStreams",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							streams Ten
+						}
+					}`,
+			err: errors.New("Could not parse number of streams"),
+		},
+		{
+			desc: "NoPDPClientStreamsArguments",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							streams
+						}
+					}`,
+			err: errors.New("Wrong argument count or unexpected line ending"),
+		},
+		{
+			desc: "NegativePDPClientStreams",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							streams -1
+						}
+					}`,
+			err: errors.New("Expected at least one stream got -1"),
+		},
+		{
+			desc: "PDPClientStreamsWithRoundRobin",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							streams 10 Round-Robin
+						}
+					}`,
+			streams: newIntPtr(10),
+			hotSpot: newBoolPtr(false),
+		},
+		{
+			desc: "PDPClientStreamsWithHotSpot",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							streams 10 Hot-Spot
+						}
+					}`,
+			streams: newIntPtr(10),
+			hotSpot: newBoolPtr(true),
+		},
+		{
+			desc: "InvalidPDPClientStreamsBalancer",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							streams 10 Unknown-Balancer
+						}
+					}`,
+			err: errors.New("Expected round-robin or hot-spot balancing but got Unknown-Balancer"),
+		},
+		{
+			desc: "TransferAttribute",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							transfer themis_id
+						}
+					}`,
+			custAttrs: map[string]custAttr{
+				"themis_id": custAttrTransfer,
+			},
+		},
+		{
+			desc: "ComplexAttributeConfig",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							attr uid request/uid
+							attr id request/id
+							transfer themis_id id
+						}
+					}`,
+			options: []*attrSetting{
+				{"uid", "request/uid", "string", false},
+				{"id", "request/id", "string", false},
+			},
+			custAttrs: map[string]custAttr{
+				"themis_id": custAttrTransfer,
+				"id":        custAttrEdns | custAttrTransfer,
+				"uid":       custAttrEdns,
+			},
+		},
+		{
+			desc: "NoTransferArguments",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							transfer
+						}
+					}`,
+			err: errors.New("Wrong argument count or unexpected line ending"),
+		},
+		{
+			desc: "DebugID",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							metrics
+						}
+					}`,
+			err: errors.New("Wrong argument count or unexpected line ending"),
+		},
+		{
+			desc: "ComplexAttributeConfigWithMetrics",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							attr uid request/uid
+							attr id request/id
+							metrics uid query_id
+						}
+					}`,
+			options: []*attrSetting{
+				{"uid", "request/uid", "string", false},
+				{"id", "request/id", "string", false},
+			},
+			custAttrs: map[string]custAttr{
+				"id":       custAttrEdns,
+				"uid":      custAttrEdns | custAttrMetrics,
+				"query_id": custAttrMetrics,
+			},
+		},
+		{
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							debug_id corednsinstance
+						}
+					}`,
+			debugID: newStringPtr("corednsinstance"),
+		},
+		{
+			desc: "NoDebugIDArguments",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							debug_id
+						}
+					}`,
+			err: errors.New("Wrong argument count or unexpected line ending"),
+		},
+		{
+			desc: "NoConnectionTimeoutArguments",
+			input: `.:53 {
+						themis NAME {
+							connection_timeout
+						}
+					}`,
+			err: errors.New("Wrong argument count or unexpected line ending"),
+		},
+		{
+			desc: "NoConnectionTimeout",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							connection_timeout no
+						}
+					}`,
+			connTimeout: newDurationPtr(-1),
+		},
+		{
+			desc: "ConnectionTimeout",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							connection_timeout 500ms
+						}
+					}`,
+			connTimeout: newDurationPtr(500 * time.Millisecond),
+		},
+		{
+			desc: "InvalidConnectionTimeout",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							connection_timeout invalid
+						}
+					}`,
+			err: errors.New("Could not parse timeout: time: invalid duration invalid"),
+		},
+		{
+			desc: "Log",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							log
+						}
+					}`,
+		},
+		{
+			desc: "TrailingLogArgument",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							log stdout
+						}
+					}`,
+			err: errors.New("Wrong argument count or unexpected line ending"),
+		},
+		{
+			desc: "MaxRequestSize",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							max_request_size 128
+						}
+					}`,
+			autoReqSize: newBoolPtr(false),
+			maxReqSize:  newIntPtr(128),
+		},
+		{
+			desc: "MaxRequestSize",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							max_request_size auto
+						}
+					}`,
+			autoReqSize: newBoolPtr(true),
+			maxReqSize:  newIntPtr(-1),
+		},
+		{
+			desc: "MaxRequestSize",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							max_request_size auto 128
+						}
+					}`,
+			autoReqSize: newBoolPtr(true),
+			maxReqSize:  newIntPtr(128),
+		},
+		{
+			desc: "NoMaxRequestSizeArguments",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							max_request_size
+						}
+					}`,
+			err: errors.New("Wrong argument count or unexpected line ending"),
+		},
+		{
+			desc: "InvalidMaxRequestSize",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							max_request_size test
+						}
+					}`,
+			err: errors.New("Could not parse PDP request size limit"),
+		},
+		{
+			desc: "OverflowMaxRequestSize",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							max_request_size 2147483648
+						}
+					}`,
+			err: errors.New("Size limit 2147483648 (> 2147483647) for PDP request is too high"),
+		},
+		{
+			desc: "MaxResponseAttributes",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							max_response_attributes 128
+						}
+					}`,
+			autoResAttrs: newBoolPtr(false),
+			maxResAttrs:  newIntPtr(128),
+		},
+		{
+			desc: "MaxResponseAttributes",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							max_response_attributes auto
+						}
+					}`,
+			autoResAttrs: newBoolPtr(true),
+			maxResAttrs:  newIntPtr(64),
+		},
+		{
+			desc: "NoMaxResponseAttributesArguments",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							max_response_attributes
+						}
+					}`,
+			err: errors.New("Wrong argument count or unexpected line ending"),
+		},
+		{
+			desc: "InvalidMaxResponseAttributes",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							max_response_attributes invalid
+						}
+					}`,
+			err: errors.New("Could not parse PDP response attributes limit"),
+		},
+		{
+			desc: "OverflowMaxResponseAttributes",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							max_response_attributes 2147483648
+						}
+					}`,
+			err: errors.New("Attributes limit 2147483648 (> 2147483647) for PDP response is too high"),
+		},
+		{
+			desc: "NoDecisionCache",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+						}
+					}`,
+			cacheTTL: newDurationPtr(0),
+		},
+		{
+			desc: "DecisionCache",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							cache
+						}
+					}`,
+			cacheTTL:   newDurationPtr(10 * time.Minute),
+			cacheLimit: newIntPtr(0),
+		},
+		{
+			desc: "DecisionCacheWithTTL",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							cache 15s
+						}
+					}`,
+			cacheTTL:   newDurationPtr(15 * time.Second),
+			cacheLimit: newIntPtr(0),
+		},
+		{
+			desc: "DecisionCacheWithTTLAndLimit",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							cache 15s 128
+						}
+					}`,
+			cacheTTL:   newDurationPtr(15 * time.Second),
+			cacheLimit: newIntPtr(128),
+		},
+		{
+			desc: "TooManyCacheArguments",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							cache too many of them
+						}
+					}`,
+			err: errors.New("Wrong argument count or unexpected line ending"),
+		},
+		{
+			desc: "InvalidCacheTTL",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							cache invalid
+						}
+					}`,
+			err: errors.New("Could not parse decision cache TTL"),
+		},
+		{
+			desc: "WrongCacheTTL",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							cache -15s
+						}
+					}`,
+			err: errors.New("Can't set decision cache TTL to"),
+		},
+		{
+			desc: "InvalidCacheLimit",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							cache 15s invalid
+						}
+					}`,
+			err: errors.New("Could not parse decision cache limit"),
+		},
+		{
+			desc: "OverflowCacheLimit",
+			input: `.:53 {
+						themis NAME {
+							endpoint 10.2.4.1:5555
+							cache 15s 2147483648
+						}
+					}`,
+			err: errors.New("Cache limit 2147483648 (> 2147483647) is too high"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			blocs, err := caddyfile.Parse("test-file", strings.NewReader(test.input), []string{"themis"})
+			d := caddyfile.NewDispenserTokens("themis", blocs[0].Tokens["themis"])
+			c := &caddy.Controller{Dispenser: d}
+			mw, err := themisParse(c)
+			if err != nil {
+				if test.err != nil {
+					if !strings.Contains(err.Error(), test.err.Error()) {
+						t.Errorf("Expected error '%v' but got '%v'\n", test.err, err)
+					}
+				} else {
+					t.Errorf("Expected no error but got '%v'\n", err)
+				}
+			} else {
+				// we consider only one Engine declared
+				for _, mwe := range mw.engines {
+					if test.err != nil {
+						t.Errorf("Expected error '%v' but got 'nil'\n", test.err)
+					} else {
+						if test.endpoints != nil {
+							if len(test.endpoints) != len(mwe.conf.endpoints) {
+								t.Errorf("Expected endpoints %v but got %v\n", test.endpoints, mwe.conf.endpoints)
+							} else {
+								for i := 0; i < len(test.endpoints); i++ {
+									if test.endpoints[i] != mwe.conf.endpoints[i] {
+										t.Errorf("Expected endpoint '%s' but got '%s'\n",
+											test.endpoints[i], mwe.conf.endpoints[i])
+									}
+								}
+							}
+						}
+
+						if test.options != nil {
+							if len(test.options) != len(mwe.conf.options) {
+								t.Errorf("Expected %d Attr options  but got %d",
+									len(test.options), len(mwe.conf.options))
+							} else {
+								for k, testAttr := range test.options {
+									mwOpt := mwe.conf.options[k]
+									if testAttr.name != mwOpt.name ||
+										testAttr.label != mwOpt.label ||
+										testAttr.attrType != mwOpt.attrType ||
+										testAttr.metrics != mwOpt.metrics {
+										t.Errorf("Expected Attr option:\n\t\"%#v\""+
+											"\nfor but got:\n\t\"%#v\"",
+											*testAttr, *mwOpt)
+									}
+								}
+
+							}
+						}
+
+						if test.debugSuffix != nil && *test.debugSuffix != mwe.conf.debugSuffix {
+							t.Errorf("Expected debug suffix %q but got %q", *test.debugSuffix, mwe.conf.debugSuffix)
+						}
+
+						if test.streams != nil && *test.streams != mwe.conf.streams {
+							t.Errorf("Expected %d streams but got %d", *test.streams, mwe.conf.streams)
+						}
+
+						if test.hotSpot != nil && *test.hotSpot != mwe.conf.hotSpot {
+							t.Errorf("Expected hotSpot=%v but got %v", *test.hotSpot, mwe.conf.hotSpot)
+						}
+
+						if test.custAttrs != nil {
+							for k, et := range test.custAttrs {
+								at, ok := mwe.conf.custAttrs[k]
+								if !ok {
+									t.Errorf("Missing conf attribute %q", k)
+								} else if et != at {
+									t.Errorf("Unexpected type of conf attribute %q; expected=%d, actual=%d", k, et, at)
+								}
+							}
+
+							for k, at := range mwe.conf.custAttrs {
+								if _, ok := test.custAttrs[k]; !ok {
+									t.Errorf("Unexpected conf attribute %q=%d", k, at)
+								}
+							}
+						}
+
+						if test.debugID != nil && *test.debugID != mwe.conf.debugID {
+							t.Errorf("Expected debug id %q but got %q", *test.debugID, mwe.conf.debugID)
+						}
+
+						if test.connTimeout != nil && *test.connTimeout != mwe.conf.connTimeout {
+							t.Errorf("Expected connection timeout %s but got %s", *test.connTimeout, mwe.conf.connTimeout)
+						}
+
+						if test.autoReqSize != nil && *test.autoReqSize != mwe.conf.autoReqSize {
+							t.Errorf("Expected automatic request size %v but got %v",
+								*test.autoReqSize, mwe.conf.autoReqSize)
+						}
+
+						if test.maxReqSize != nil && *test.maxReqSize != mwe.conf.maxReqSize {
+							t.Errorf("Expected request size limit %d but got %d", *test.maxReqSize, mwe.conf.maxReqSize)
+						}
+
+						if test.autoResAttrs != nil && *test.autoResAttrs != mwe.conf.autoResAttrs {
+							t.Errorf("Expected automatic response attributes %v but got %v",
+								*test.autoResAttrs, mwe.conf.autoResAttrs)
+						}
+
+						if test.maxResAttrs != nil && *test.maxResAttrs != mwe.conf.maxResAttrs {
+							t.Errorf("Expected response attributes limit %d but got %d",
+								*test.maxResAttrs, mwe.conf.maxResAttrs)
+						}
+
+						if test.cacheTTL != nil && *test.cacheTTL != mwe.conf.cacheTTL {
+							t.Errorf("Expected cache TTL %s but got %s", *test.cacheTTL, mwe.conf.cacheTTL)
+						}
+
+						if test.cacheLimit != nil && *test.cacheLimit != mwe.conf.cacheLimit {
+							t.Errorf("Expected cache limit %d but got %d", *test.cacheLimit, mwe.conf.cacheLimit)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func newStringPtr(s string) *string {
+	return &s
+}
+
+func newIntPtr(n int) *int {
+	return &n
+}
+
+func newBoolPtr(b bool) *bool {
+	return &b
+}
+
+func newDurationPtr(d time.Duration) *time.Duration {
+	return &d
+}

--- a/plugin/themis/dns_test.go
+++ b/plugin/themis/dns_test.go
@@ -1,0 +1,166 @@
+package themisplugin
+
+import (
+	"net"
+
+	"github.com/miekg/dns"
+)
+
+func makeTestDNSMsg(n string, t uint16, c uint16) *dns.Msg {
+	out := new(dns.Msg)
+	out.Question = make([]dns.Question, 1)
+	out.Question[0] = dns.Question{
+		Name:   dns.Fqdn(n),
+		Qtype:  t,
+		Qclass: c,
+	}
+	return out
+}
+
+func appendAnswer(m *dns.Msg, rr ...dns.RR) {
+	if m.Answer == nil {
+		m.Answer = []dns.RR{}
+	}
+
+	m.Answer = append(m.Answer, rr...)
+}
+
+func newA(a net.IP) dns.RR {
+	out := new(dns.A)
+	out.Hdr.Name = "."
+	out.Hdr.Rrtype = dns.TypeA
+	out.A = a
+
+	return out
+}
+
+func newAAAA(a net.IP) dns.RR {
+	out := new(dns.AAAA)
+	out.Hdr.Name = "."
+	out.Hdr.Rrtype = dns.TypeAAAA
+	out.AAAA = a
+
+	return out
+}
+
+func newCNAME(s string) dns.RR {
+	out := new(dns.CNAME)
+	out.Hdr.Name = "."
+	out.Hdr.Rrtype = dns.TypeCNAME
+	out.Target = dns.Fqdn(s)
+
+	return out
+}
+
+func makeTestDNSMsgWithEdns0(n string, t uint16, c uint16, o ...*dns.OPT) *dns.Msg {
+	out := makeTestDNSMsg(n, t, c)
+
+	extra := make([]dns.RR, len(o))
+	for i, o := range o {
+		extra[i] = o
+	}
+
+	out.Extra = extra
+	return out
+}
+
+func newEdns0(o ...dns.EDNS0) *dns.OPT {
+	out := new(dns.OPT)
+	out.Hdr.Name = "."
+	out.Hdr.Rrtype = dns.TypeOPT
+	out.Option = o
+
+	return out
+}
+
+func copyEdns0(in ...*dns.OPT) []*dns.OPT {
+	out := make([]*dns.OPT, len(in))
+	for i, o := range in {
+		out[i] = new(dns.OPT)
+		out[i].Hdr = o.Hdr
+		out[i].Option = make([]dns.EDNS0, len(o.Option))
+		copy(out[i].Option, o.Option)
+	}
+
+	return out
+}
+
+func newEdns0Cookie(s string) dns.EDNS0 {
+	out := new(dns.EDNS0_COOKIE)
+	out.Code = dns.EDNS0COOKIE
+	out.Cookie = s
+
+	return out
+}
+
+func newEdns0Local(c uint16, b []byte) dns.EDNS0 {
+	out := new(dns.EDNS0_LOCAL)
+	out.Code = c
+	out.Data = b
+
+	return out
+}
+
+func newEdns0Subnet(ip net.IP) dns.EDNS0 {
+	out := new(dns.EDNS0_SUBNET)
+	out.Code = dns.EDNS0SUBNET
+	if ipv4 := ip.To4(); ipv4 != nil {
+		out.Family = 1
+		out.SourceNetmask = 32
+		out.Address = ipv4
+	} else if ipv6 := ip.To16(); ipv6 != nil {
+		out.Family = 2
+		out.SourceNetmask = 128
+		out.Address = ipv6
+	}
+	out.SourceScope = 0
+
+	return out
+}
+
+type testAddressedNonwriter struct {
+	dns.ResponseWriter
+	ra  net.Addr
+	Msg *dns.Msg
+}
+
+type testUDPAddr struct {
+	addr string
+}
+
+func newTestAddressedNonwriter(ra string) *testAddressedNonwriter {
+	return &testAddressedNonwriter{
+		ResponseWriter: nil,
+		ra:             newUDPAddr(ra),
+	}
+}
+
+func newTestAddressedNonwriterWithAddr(ra net.Addr) *testAddressedNonwriter {
+	return &testAddressedNonwriter{
+		ResponseWriter: nil,
+		ra:             ra,
+	}
+}
+
+func (w *testAddressedNonwriter) RemoteAddr() net.Addr {
+	return w.ra
+}
+
+func (w *testAddressedNonwriter) WriteMsg(res *dns.Msg) error {
+	w.Msg = res
+	return nil
+}
+
+func newUDPAddr(addr string) *testUDPAddr {
+	return &testUDPAddr{
+		addr: addr,
+	}
+}
+
+func (a *testUDPAddr) String() string {
+	return a.addr
+}
+
+func (a *testUDPAddr) Network() string {
+	return "udp"
+}

--- a/plugin/themis/metrics.go
+++ b/plugin/themis/metrics.go
@@ -1,0 +1,272 @@
+package themisplugin
+
+import (
+	"errors"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metrics"
+	"github.com/infobloxopen/themis/pdp"
+	"github.com/mholt/caddy"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	BucketCnt = 16
+	FreshCnt  = 10
+)
+
+// SlicedCounter stores the counter value both as a single number and as a separate
+// values per second. The sum of values per second is synchronized with total value
+// but not guaranteed to be equal at any moment of time
+type SlicedCounter struct {
+	oldestValid uint32
+	total       uint32
+	buckets     [BucketCnt]uint32
+}
+
+// NewSlicedCounter creates new SlicedCounter
+func NewSlicedCounter(ut uint32) *SlicedCounter {
+	return &SlicedCounter{oldestValid: ut}
+}
+
+// Total returns the counter value
+func (sc *SlicedCounter) Total() uint32 {
+	return atomic.LoadUint32(&sc.total)
+}
+
+// Inc increments the latest and total counters. Can be called simultaneously
+// from different goroutines
+func (sc *SlicedCounter) Inc(ut uint32) bool {
+	oldest := atomic.LoadUint32(&sc.oldestValid)
+	if ut-oldest >= BucketCnt {
+		return false
+	}
+	atomic.AddUint32(&sc.total, 1)
+	atomic.AddUint32(&sc.buckets[ut%BucketCnt], 1)
+	return true
+}
+
+// EraseStale erases the values from stale buckets, decrements the total counter
+// by the sum of erased values, and updates the oldestValid time. Should be run
+// in single goroutine
+func (sc *SlicedCounter) EraseStale(ut uint32) {
+	oldest := atomic.LoadUint32(&sc.oldestValid)
+	stale := ut - FreshCnt
+	if stale >= oldest+BucketCnt {
+		oldest = stale - BucketCnt + 1
+		atomic.StoreUint32(&sc.oldestValid, oldest)
+	}
+	for oldest <= stale {
+		cnt := atomic.SwapUint32(&sc.buckets[oldest%BucketCnt], 0)
+		atomic.AddUint32(&sc.total, -cnt)
+		atomic.AddUint32(&sc.oldestValid, 1)
+		oldest++
+	}
+}
+
+const (
+	AttrGaugeStopped = iota
+	AttrGaugeStarted
+	AttrGaugeStopping
+)
+
+const (
+	DefaultEraseInterval = 500 * time.Millisecond
+	DefaultQueryChanSize = 1000
+)
+
+// AttrGauge manages GaugeVec for attributes. GaugeVec holds the
+// counters for recently received (last FreshCnt seconds) DNS queries
+// per attribute/value
+type AttrGauge struct {
+	perAttr  map[string]map[string]*SlicedCounter
+	pgv      *prometheus.GaugeVec
+	qChan    chan pdp.AttributeAssignment
+	nameChan chan string
+	timeFunc func() uint32
+	errCnt   uint32
+	state    uint32
+}
+
+// NewAttrGauge constructs new AttrGauge object
+func NewAttrGauge() *AttrGauge {
+	return &AttrGauge{
+		perAttr: make(map[string]map[string]*SlicedCounter),
+		pgv: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: plugin.Namespace,
+			Subsystem: "policy",
+			Name:      "recent_queries",
+			Help:      "Gauge of recent queries per Attrubute value.",
+		}, []string{"attribute", "value"}),
+		qChan:    make(chan pdp.AttributeAssignment),
+		nameChan: make(chan string),
+		timeFunc: unixTime,
+	}
+}
+
+// globalAttrGauge object is used across all policy plugin instances
+// including instances from different corefile blocks and
+// new/old instances during graceful restart
+var globalAttrGauge = NewAttrGauge()
+
+// Start starts goroutine which reads and handles data from channels
+func (g *AttrGauge) Start(tickInt time.Duration, chSize int) {
+	if atomic.CompareAndSwapUint32(&g.state, AttrGaugeStopped, AttrGaugeStarted) {
+		ch := make(chan pdp.AttributeAssignment, chSize)
+		g.qChan = ch
+		go func() {
+			timer := time.NewTimer(tickInt)
+			for {
+				if atomic.CompareAndSwapUint32(&g.state, AttrGaugeStopping, AttrGaugeStopped) {
+					break
+				}
+				select {
+				case name := <-g.nameChan:
+					g.addAttribute(name)
+				case attr := <-ch:
+					g.synchInc(attr)
+				case <-timer.C:
+					eCnt := g.tick()
+					if eCnt != 0 {
+						log.Printf("[WARN] Policy metrics: %d queries was skipped", eCnt)
+					}
+					timer.Reset(tickInt)
+				}
+			}
+		}()
+	}
+}
+
+// Stop stops goroutine which reads and handles data from channels
+func (g *AttrGauge) Stop() {
+	if g == nil {
+		return
+	}
+	if !atomic.CompareAndSwapUint32(&g.state, AttrGaugeStarted, AttrGaugeStopping) {
+		return
+	}
+	for atomic.LoadUint32(&g.state) != AttrGaugeStopped {
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// AddAttribute adds new attribute names to gauge. It's safe to call it from
+// any goroutine. The AttrGauge should be started before calling AddAttributes
+func (g *AttrGauge) AddAttributes(attrNames ...string) {
+	for _, name := range attrNames {
+		g.nameChan <- name
+	}
+}
+
+// addAttribute adds new attribute name to gauge. Should be called synchronously
+func (g *AttrGauge) addAttribute(attrName string) {
+	if g.perAttr[attrName] == nil {
+		g.perAttr[attrName] = make(map[string]*SlicedCounter)
+	}
+}
+
+// Inc increments the counter corresponding to the attr. It's safe
+// to call it from any goroutine. The AttrGauge should be started before
+// calling Inc
+func (g *AttrGauge) Inc(attr pdp.AttributeAssignment) {
+	if g == nil {
+		return
+	}
+
+	select {
+	case g.qChan <- attr:
+	default:
+		g.ErrorInc()
+	}
+}
+
+// synchInc increments internal counter corresponding to the attr.
+// The actual prometheus value is not updated in this method.
+// Should be called synchronously
+func (g *AttrGauge) synchInc(attr pdp.AttributeAssignment) {
+	ut := g.timeFunc()
+	id := attr.GetID()
+	v := serializeOrPanic(attr)
+	sc := g.perAttr[id][v]
+	if sc == nil {
+		sc = NewSlicedCounter(ut)
+		g.perAttr[id][v] = sc
+	}
+	if sc.Inc(ut) {
+		return
+	}
+	g.ErrorInc()
+}
+
+// tick synchronises prometheus gauge with internal counters.
+// Should be called synchronously
+func (g *AttrGauge) tick() uint32 {
+	ut := g.timeFunc()
+	for attr, amap := range g.perAttr {
+		for val, sc := range amap {
+			sc.EraseStale(ut)
+			total := sc.Total()
+			if total > 0 {
+				g.pgv.WithLabelValues(attr, val).Set(float64(total))
+				continue
+			}
+			g.pgv.DeleteLabelValues(attr, val)
+			delete(amap, val)
+		}
+		g.pgv.WithLabelValues(attr, "VALUES_COUNT").Set(float64(len(amap)))
+	}
+	return atomic.SwapUint32(&g.errCnt, 0)
+}
+
+// ErrorInc increments error counter
+func (g *AttrGauge) ErrorInc() {
+	atomic.AddUint32(&g.errCnt, 1)
+}
+
+// unixTime returns number of seconds since Unix epoch
+func unixTime() uint32 {
+	return uint32(time.Now().Unix())
+}
+
+// SetupMetrics checks for configured metrics attributes and starts and
+// configures globalAttrGauge as needed
+func (pp *ThemisEngine) SetupMetrics(c *caddy.Controller) error {
+	attrNames := []string{}
+	for attr, t := range pp.conf.custAttrs {
+		if !t.isMetrics() {
+			continue
+		}
+
+		attrNames = append(attrNames, attr)
+
+		for _, opt := range pp.conf.options {
+			if opt.name == attr {
+				opt.metrics = true
+			}
+		}
+	}
+	if len(attrNames) > 0 {
+		if mh := dnsserver.GetConfig(c).Handler("prometheus"); mh != nil {
+			if m, ok := mh.(*metrics.Metrics); ok {
+				metricsOnce.Do(func() {
+					m.MustRegister(globalAttrGauge.pgv)
+					// The globalAttrGauge is started once and is not stopped
+					// until process termination
+					globalAttrGauge.Start(DefaultEraseInterval, DefaultQueryChanSize)
+				})
+				globalAttrGauge.AddAttributes(attrNames...)
+				pp.attrGauges = globalAttrGauge
+				return nil
+			}
+		}
+		return errors.New("can't find prometheus plugin")
+	}
+	return nil
+}
+
+var metricsOnce sync.Once

--- a/plugin/themis/metrics_test.go
+++ b/plugin/themis/metrics_test.go
@@ -1,0 +1,448 @@
+package themisplugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/infobloxopen/themis/pdp"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// ============= SlicedCounter tests ==============
+
+func TestSlicedCounterInc(t *testing.T) {
+	var utime uint32 = 100
+	sc := NewSlicedCounter(100)
+
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			for {
+				ut := atomic.LoadUint32(&utime)
+				if !sc.Inc(ut) {
+					if ut < 100+BucketCnt {
+						t.Errorf("Inc unexpectedly returned false")
+					}
+					break
+				}
+				if ut >= 100+BucketCnt {
+					t.Errorf("Inc unexpectedly returned true")
+					break
+				}
+				time.Sleep(time.Nanosecond)
+			}
+			wg.Done()
+		}()
+	}
+	for i := 0; i <= BucketCnt; i++ {
+		atomic.AddUint32(&utime, 1)
+		time.Sleep(time.Microsecond)
+	}
+	wg.Wait()
+
+	checkTotal(t, sc)
+}
+
+func TestNoStale(t *testing.T) {
+	sc := newTestSlicedCounter(100)
+	sc.EraseStale(105)
+
+	for i := 0; i < BucketCnt; i++ {
+		if sc.buckets[i] != uint32(i+10) {
+			t.Errorf("bucket[%d] unexpectedly was erased", i)
+		}
+	}
+
+	checkTotal(t, sc)
+}
+
+func Test6Stale(t *testing.T) {
+	sc := newTestSlicedCounter(100)
+	sc.EraseStale(115)
+
+	for i := 0; i < 4; i++ {
+		if sc.buckets[i] != uint32(i+10) {
+			t.Errorf("bucket[%d] unexpectedly was erased", i)
+		}
+	}
+	for i := 4; i < 10; i++ {
+		if sc.buckets[i] != 0 {
+			t.Errorf("bucket[%d] unexpectedly was not erased", i)
+		}
+	}
+	for i := 10; i < 16; i++ {
+		if sc.buckets[i] != uint32(i+10) {
+			t.Errorf("bucket[%d] unexpectedly was erased", i)
+		}
+	}
+
+	checkTotal(t, sc)
+}
+
+func TestAllStale(t *testing.T) {
+	sc := newTestSlicedCounter(100)
+	sc.EraseStale(130)
+
+	for i := 0; i < BucketCnt; i++ {
+		if sc.buckets[i] != 0 {
+			t.Errorf("bucket[%d] unexpectedly was not erased", i)
+		}
+	}
+
+	checkTotal(t, sc)
+}
+
+func TestIncVsAllStale(t *testing.T) {
+	sc := newTestSlicedCounter(100)
+	var testTime uint32 = 140
+	var utime uint32 = testTime
+
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			for {
+				ut := atomic.LoadUint32(&utime)
+				sc.Inc(ut)
+				if ut > testTime {
+					break
+				}
+				time.Sleep(time.Nanosecond)
+			}
+			wg.Done()
+		}()
+	}
+	sc.EraseStale(testTime)
+
+	atomic.AddUint32(&utime, 1)
+	wg.Wait()
+
+	if sc.buckets[utime%BucketCnt] != 10 {
+		t.Errorf("Unexpected counter after Erase, expected 10, got %d", sc.buckets[utime%BucketCnt])
+	}
+	checkTotal(t, sc)
+}
+
+func TestIncVsPartiallyStale(t *testing.T) {
+	sc := newTestSlicedCounter(100)
+	var testTime uint32 = 114
+	var utime uint32 = testTime
+
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			for {
+				ut := atomic.LoadUint32(&utime)
+				if !sc.Inc(ut) {
+					t.Errorf("Inc unexpectedly returned false")
+				}
+				if ut > testTime {
+					break
+				}
+				time.Sleep(time.Nanosecond)
+			}
+			wg.Done()
+		}()
+	}
+	sc.EraseStale(testTime)
+
+	atomic.AddUint32(&utime, 1)
+	wg.Wait()
+
+	checkTotal(t, sc)
+}
+
+// ============= AttrGauge tests ==============
+
+func TestStartStop(t *testing.T) {
+	ag := newTestAttrGauge()
+
+	ag.Start(10*time.Millisecond, 20)
+	time.Sleep(100 * time.Millisecond)
+	if atomic.LoadUint32(&ag.state) != AttrGaugeStarted {
+		t.Errorf("AttrGauge has not started")
+	}
+
+	ag.Stop()
+	time.Sleep(100 * time.Millisecond)
+	if atomic.LoadUint32(&ag.state) != AttrGaugeStopped {
+		t.Errorf("AttrGauge has not stopped")
+	}
+}
+
+func TestNegativeStop(t *testing.T) {
+	ag := newTestAttrGauge()
+
+	ag.state = AttrGaugeStopped
+	ag.Stop()
+	if atomic.LoadUint32(&ag.state) == AttrGaugeStopping {
+		t.Errorf("AttrGauge is unexpectedly stopping")
+	}
+
+	ag.state = AttrGaugeStopping
+	ag.Stop()
+	if atomic.LoadUint32(&ag.state) != AttrGaugeStopping {
+		t.Errorf("AttrGauge is unexpectedly stopped")
+	}
+}
+
+func TestAttrGaugeNil(t *testing.T) {
+	var ag *AttrGauge
+
+	ag.Inc(testAttr())
+	ag.Stop()
+}
+
+func TestAttrGaugeInc(t *testing.T) {
+	ag := newTestAttrGauge()
+	attr := testAttr()
+
+	setTestTime(100)
+	ag.synchInc(attr)
+	ag.tick()
+	scVal := totalVal(t, ag, attr)
+	gVal, err := gaugeVal(t, ag, attr)
+	if err := checkVal(err, gVal, scVal, 1); err != nil {
+		t.Error(err)
+	}
+
+	setTestTime(101)
+	ag.synchInc(attr)
+	ag.tick()
+	scVal = totalVal(t, ag, attr)
+	gVal, err = gaugeVal(t, ag, attr)
+	if err := checkVal(err, gVal, scVal, 2); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAttrGaugeTick(t *testing.T) {
+	ag := newTestAttrGauge()
+	attr := testAttr()
+
+	for i := 100; i < 120; i++ {
+		setTestTime(uint32(i))
+		ag.synchInc(attr)
+	}
+	scVal := totalVal(t, ag, attr)
+	if scVal != 16 {
+		t.Errorf("unexpected counter, expected %d, got %d", 16, scVal)
+	}
+
+	setTestTime(120)
+	eCnt := ag.tick()
+	if eCnt != 4 {
+		t.Errorf("unexpected error count, expected %d, got %d", 4, eCnt)
+	}
+	scVal = totalVal(t, ag, attr)
+	gVal, err := gaugeVal(t, ag, attr)
+	if err := checkVal(err, gVal, scVal, 5); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAttrGaugeEraseValue(t *testing.T) {
+	ag := newTestAttrGauge()
+	attr := testAttr()
+
+	setTestTime(100)
+	ag.Inc(attr)
+	setTestTime(120)
+	ag.tick()
+	scVal := totalVal(t, ag, attr)
+	gVal, err := gaugeVal(t, ag, attr)
+	if err := checkVal(err, gVal, scVal, 0); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAttrGaugeSubsequentTicks(t *testing.T) {
+	ag := newTestAttrGauge()
+	ag.Start(10*time.Millisecond, 20)
+	attr := testAttr()
+
+	setTestTime(93)
+	ag.Inc(attr)
+	time.Sleep(100 * time.Millisecond)
+	setTestTime(94)
+	ag.Inc(attr)
+	time.Sleep(100 * time.Millisecond)
+	gVal, err := gaugeVal(t, ag, attr)
+	if err := checkVal(err, gVal, gVal, 2); err != nil {
+		t.Error(err)
+	}
+
+	setTestTime(103)
+	time.Sleep(100 * time.Millisecond)
+	gVal, err = gaugeVal(t, ag, attr)
+	if err := checkVal(err, gVal, gVal, 1); err != nil {
+		t.Error(err)
+	}
+
+	setTestTime(104)
+	time.Sleep(100 * time.Millisecond)
+	gVal, err = gaugeVal(t, ag, attr)
+	if err := checkVal(err, gVal, gVal, 0); err != nil {
+		t.Error(err)
+	}
+
+	ag.Stop()
+}
+
+func TestAttrGaugeErrorInc(t *testing.T) {
+	ag := newTestAttrGauge()
+	attr := testAttr()
+
+	setTestTime(93)
+	ag.Inc(attr)
+	ag.Inc(attr)
+	ag.Inc(attr)
+
+	if ag.errCnt != 3 {
+		t.Errorf("unexpected error count, expected %d, got %d", 3, ag.errCnt)
+	}
+}
+
+func TestAttrGaugeAddAttributes(t *testing.T) {
+	ag := newTestAttrGauge()
+	setTestTime(100)
+
+	ag.Start(10*time.Millisecond, DefaultQueryChanSize)
+	// Just make sure the test doesn't panic
+
+	ag.AddAttributes("test_attr1")
+	ag.Inc(pdp.MakeStringAssignment("test_attr1", "test_value1"))
+
+	ag.AddAttributes("test_attr2")
+	ag.Inc(pdp.MakeStringAssignment("test_attr2", "test_value2"))
+
+	ag.Stop()
+}
+
+func TestAttrGaugeAddAttributeAgain(t *testing.T) {
+	ag := newTestAttrGauge()
+	setTestTime(100)
+
+	ag.Start(10*time.Millisecond, DefaultQueryChanSize)
+	attr := testAttr()
+
+	ag.Inc(attr)
+	ag.AddAttributes("test_attr")
+	ag.Inc(attr)
+
+	time.Sleep(100 * time.Millisecond)
+	ag.Stop()
+	gVal, err := gaugeVal(t, ag, attr)
+	if err = checkVal(err, gVal, gVal, 2); err != nil {
+		t.Error(err)
+	}
+}
+
+// ============== utility functions ===============
+
+func newTestSlicedCounter(ut uint32) *SlicedCounter {
+	sc := NewSlicedCounter(ut)
+	for i := 0; i < BucketCnt; i++ {
+		sc.buckets[i] = uint32(i + 10)
+		sc.total += sc.buckets[i]
+	}
+	return sc
+}
+
+func logSc(t *testing.T, sc *SlicedCounter) {
+	for i := 0; i < BucketCnt; i++ {
+		t.Logf("bucket[%d] == %d", i, sc.buckets[i])
+	}
+}
+
+func checkTotal(t *testing.T, sc *SlicedCounter) {
+	var total uint32
+	for i := 0; i < BucketCnt; i++ {
+		total += sc.buckets[i]
+	}
+	if total != sc.Total() {
+		t.Errorf("Unexpected total, expected=%d, actual=%d", total, sc.Total())
+	}
+}
+
+func testAttr() pdp.AttributeAssignment {
+	return pdp.MakeStringAssignment("test_attr", "test_value")
+}
+
+var utime uint32
+
+func testTime() uint32 {
+	return atomic.LoadUint32(&utime)
+}
+
+func setTestTime(t uint32) {
+	atomic.StoreUint32(&utime, t)
+}
+
+func newTestAttrGauge() *AttrGauge {
+	ag := NewAttrGauge()
+	ag.addAttribute("test_attr")
+	ag.timeFunc = testTime
+	return ag
+}
+
+func totalVal(t *testing.T, ag *AttrGauge, attr pdp.AttributeAssignment) uint32 {
+	if vMap, ok := ag.perAttr[attr.GetID()]; ok {
+		if sc, ok := vMap[serializeOrPanic(attr)]; ok {
+			return sc.Total()
+		}
+	}
+	return 0
+}
+
+func gaugeVal(t *testing.T, ag *AttrGauge, attr pdp.AttributeAssignment) (uint32, error) {
+	g, e := ag.pgv.GetMetricWithLabelValues(attr.GetID(), serializeOrPanic(attr))
+	if e != nil {
+		return 0, e
+	}
+	metric := &dto.Metric{}
+	g.Write(metric)
+	out, e := json.Marshal(metric)
+	if e != nil {
+		return 0, e
+	}
+
+	result := make(map[string]interface{})
+	e = json.Unmarshal(out, &result)
+	if e != nil {
+		return 0, e
+	}
+	if v, ok := result["gauge"]; ok {
+		if vMap, ok := v.(map[string]interface{}); ok {
+			if v, ok := vMap["value"]; ok {
+				if v, ok := v.(float64); ok {
+					return uint32(v), nil
+				}
+			}
+		}
+	}
+	return 0, fmt.Errorf("Gauge value not found")
+}
+
+func checkVal(err error, gVal, scVal, expVal uint32) error {
+	if err != nil {
+		return fmt.Errorf("Failed to get gauge value - %s", err)
+	}
+	if gVal != expVal {
+		return fmt.Errorf("unexpected gauge value, expected %d, got %d", expVal, gVal)
+	}
+	if gVal != scVal {
+		return fmt.Errorf("gauge value mismatch, gauge=%d, slicedCounter=%d", gVal, scVal)
+	}
+	return nil
+}
+
+func resetGlobals() {
+
+}

--- a/plugin/themis/pool.go
+++ b/plugin/themis/pool.go
@@ -1,0 +1,43 @@
+package themisplugin
+
+import (
+	"sync"
+
+	"github.com/infobloxopen/themis/pdp"
+)
+
+type attrPool struct {
+	s int
+	a *sync.Pool
+}
+
+func makeAttrPool(size int, dummy bool) attrPool {
+	p := attrPool{s: size}
+	if !dummy {
+		p.a = &sync.Pool{
+			New: func() interface{} {
+				return p.newAttrs()
+			},
+		}
+	}
+
+	return p
+}
+
+func (p attrPool) newAttrs() []pdp.AttributeAssignment {
+	return make([]pdp.AttributeAssignment, p.s)
+}
+
+func (p attrPool) Get() []pdp.AttributeAssignment {
+	if p.a != nil {
+		return p.a.Get().([]pdp.AttributeAssignment)
+	}
+
+	return p.newAttrs()
+}
+
+func (p attrPool) Put(a []pdp.AttributeAssignment) {
+	if p.a != nil {
+		p.a.Put(a)
+	}
+}

--- a/plugin/themis/pool_test.go
+++ b/plugin/themis/pool_test.go
@@ -1,0 +1,25 @@
+package themisplugin
+
+import "testing"
+
+func TestAttrPool(t *testing.T) {
+	p := makeAttrPool(10, false)
+
+	a := p.Get()
+	if len(a) != 10 {
+		t.Errorf("expected buffer of %d attributes but got %d %#v", 10, len(a), a)
+	}
+
+	p.Put(a)
+}
+
+func TestDummyAttrPool(t *testing.T) {
+	p := makeAttrPool(10, true)
+
+	a := p.Get()
+	if len(a) != 10 {
+		t.Errorf("expected buffer of %d attributes but got %d %#v", 10, len(a), a)
+	}
+
+	p.Put(a)
+}

--- a/plugin/themis/setup.go
+++ b/plugin/themis/setup.go
@@ -1,0 +1,46 @@
+package themisplugin
+
+import (
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	"github.com/mholt/caddy"
+)
+
+func init() {
+	caddy.RegisterPlugin(ThemisPluginName, caddy.Plugin{
+		ServerType: "dns",
+		Action:     setup,
+	})
+}
+
+func setup(c *caddy.Controller) error {
+	t, err := themisParse(c)
+
+	if err != nil {
+		return plugin.Error("themis", err)
+	}
+
+	for _, e := range t.engines {
+		c.OnStartup(func() error {
+			e.trace = dnsserver.GetConfig(c).Handler("trace")
+			err := e.connect()
+			if err != nil {
+				return plugin.Error("themis", err)
+			}
+
+			return e.SetupMetrics(c)
+		})
+
+		c.OnShutdown(func() error {
+			e.closeConn()
+			return nil
+		})
+	}
+
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		t.next = next
+		return t
+	})
+
+	return nil
+}

--- a/plugin/themis/test_data/Corefile
+++ b/plugin/themis/test_data/Corefile
@@ -1,0 +1,12 @@
+.:9999 {
+     policy {
+         pdp policy.json actions.json
+         passthrough infoblox.com.
+         log
+         max_request_size 10240
+         max_response_attributes 20
+     }
+    proxy . /etc/resolv.conf
+    log
+}
+

--- a/plugin/themis/test_data/actions.json
+++ b/plugin/themis/test_data/actions.json
@@ -1,0 +1,13 @@
+{
+  "id": "actions",
+  "items": {
+    "domain-actions": {
+      "keys": ["domain"],
+      "type": "string",
+      "data": {
+        "google.com": "PermitAction",
+        "yahoo.com": "DenyAction"
+      }
+    }
+  }
+}

--- a/plugin/themis/test_data/policy.json
+++ b/plugin/themis/test_data/policy.json
@@ -1,0 +1,112 @@
+{
+  "attributes": {
+    "strAttr": "string",
+    "domain_name": "domain",
+    "type": "string"
+  },
+  "policies": 
+{
+  "id": "Parent policy set",
+  "alg": "FirstApplicableEffect",
+  "policies": [
+  {
+    "id": "Query Policy Set",
+    "target": [
+      {
+       "equal": [
+          {"attr": "type"},
+          {"val": {"type": "string", "content": "query"}}
+       ]
+      }
+     ],
+    "alg": {
+      "id": "Mapper",
+      "default": "DefaultPermitAction",
+      "map": {
+        "selector": {
+          "uri": "local:actions/domain-actions",
+          "type": "string",
+          "path": [
+            {
+              "attr": "domain_name"
+            }
+          ]
+        }
+      },
+      "alg": "DenyOverrides"
+    },
+    "rules": [
+      {
+        "id": "PermitAction",
+        "effect": "Permit",
+        "obligations": [
+           {
+            "strAttr": {
+                "val": {"type":"string", "content": "PermitObligations"}
+            }
+          }
+        ]
+      },
+      {
+        "id": "DenyAction",
+        "effect": "Deny",
+        "obligations": [
+           {
+            "strAttr": {
+                "val": {"type":"string", "content": "DenyObligations"}
+            }
+          }
+        ]
+      },
+      {
+        "id": "DefaultDenyAction",
+        "effect": "Deny",
+        "obligations": [
+           {
+            "strAttr": {
+                "val": {"type":"string", "content": "DefaultDenyObligations"}
+            }
+          }
+        ]
+      },
+      {
+        "id": "DefaultPermitAction",
+        "effect": "Permit",
+        "obligations": [
+           {
+            "strAttr": {
+                "val": {"type":"string", "content": "DefaultPermitObligations"}
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+     "id": "Response Policy Set",
+    "target": [
+      {
+       "equal": [
+          {"attr": "type"},
+          {"val": {"type": "string", "content": "response"}}
+       ]
+      }
+     ],
+     "alg": "FirstApplicableEffect",
+     "rules": [
+        {
+          "effect": "Permit",
+          "obligations": [
+             {
+              "strAttr": {
+                  "val": {"type":"string", "content": "ResponsePermitObligations"}
+              }
+            }
+          ]
+        }
+      ]
+    }
+   ]
+  }
+}
+

--- a/plugin/themis/themis.go
+++ b/plugin/themis/themis.go
@@ -1,0 +1,103 @@
+package themisplugin
+
+import (
+	"errors"
+	"github.com/coredns/coredns/request"
+	"github.com/coredns/policy/plugin/firewall/policy"
+	"github.com/coredns/policy/plugin/pkg/rqdata"
+	"sync"
+
+	"context"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/miekg/dns"
+
+	"github.com/infobloxopen/themis/pdp"
+	"github.com/infobloxopen/themis/pep"
+)
+
+var errInvalidAction = errors.New("invalid action")
+
+const ThemisPluginName = "themis"
+
+// ThemisPlugin represents a plugin instance that can validate DNS
+// requests and replies using PDP server.
+
+type ThemisEngine struct {
+	conf            config
+	trace           plugin.Handler
+	next            plugin.Handler
+	pdp             pep.Client
+	attrPool        attrPool
+	attrGauges      *AttrGauge
+	connAttempts    map[string]*uint32
+	unkConnAttempts *uint32
+	mapping *rqdata.Mapping
+	wg              sync.WaitGroup
+}
+
+func newThemisEngine() *ThemisEngine {
+	return &ThemisEngine{
+		conf: config{
+			options:     make([]*attrSetting, 0),
+			custAttrs:   make(map[string]custAttr),
+			connTimeout: -1,
+			maxReqSize:  -1,
+			maxResAttrs: 64,
+		},
+		connAttempts:    make(map[string]*uint32),
+		unkConnAttempts: new(uint32),
+		mapping:rqdata.NewMapping(""),
+	}
+}
+
+func (p *ThemisEngine) BuildQueryData(ctx context.Context, state request.Request) (interface{}, error) {
+	ah := newAttrHolderWithContext(ctx, rqdata.NewExtractor(state, p.mapping), p.conf.options, p.attrGauges)
+	return ah, nil
+}
+
+func (p *ThemisEngine) BuildReplyData(ctx context.Context, state request.Request, queryData interface{}) (interface{}, error) {
+	ah := queryData.(*attrHolder)
+	ah.prepareResponseFromContext(ctx, rqdata.NewExtractor(state, p.mapping))
+	return ah, nil
+}
+
+func (p *ThemisEngine) BuildRule(args []string) (policy.Rule, error) {
+	return p, nil
+}
+
+func (p *ThemisEngine) Evaluate(data interface{}) (byte, error) {
+	ah := data.(*attrHolder)
+	var attrsRequest []pdp.AttributeAssignment
+	if !p.conf.autoResAttrs {
+		attrsRequest = p.attrPool.Get()
+		defer p.attrPool.Put(attrsRequest)
+	}
+	// validate domain name (validation #1)
+	if err := p.validate(ah, attrsRequest); err != nil {
+		return dns.RcodeSuccess, err
+	}
+	return ah.action, nil
+}
+
+type ThemisPlugin struct {
+	engines map[string]*ThemisEngine
+	next    plugin.Handler
+}
+
+func newThemisPlugin() *ThemisPlugin {
+	return &ThemisPlugin{engines: make(map[string]*ThemisEngine)}
+}
+
+// Name implements the Handler interface
+func (p *ThemisPlugin) Name() string { return ThemisPluginName }
+
+// ServeDNS implements the Handler interface.
+func (p *ThemisPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	// do nothing
+	return plugin.NextOrFailure(p.Name(), p.next, ctx, w, r)
+}
+
+func (p *ThemisPlugin) GetEngine(name string) policy.Engine {
+	return p.engines[name]
+}

--- a/plugin/themis/themis.go
+++ b/plugin/themis/themis.go
@@ -66,7 +66,7 @@ func (p *ThemisEngine) BuildRule(args []string) (policy.Rule, error) {
 	return p, nil
 }
 
-func (p *ThemisEngine) Evaluate(data interface{}) (byte, error) {
+func (p *ThemisEngine) Evaluate(data interface{}) (int, error) {
 	ah := data.(*attrHolder)
 	var attrsRequest []pdp.AttributeAssignment
 	if !p.conf.autoResAttrs {
@@ -77,7 +77,7 @@ func (p *ThemisEngine) Evaluate(data interface{}) (byte, error) {
 	if err := p.validate(ah, attrsRequest); err != nil {
 		return dns.RcodeSuccess, err
 	}
-	return ah.action, nil
+	return int(ah.action), nil
 }
 
 type ThemisPlugin struct {


### PR DESCRIPTION
It is refactored to ensure compilation, after the changes on Firewall:
- use of rqdata instead of Metadata for information of the request itself
- move of code from plugin/pkg to plugin/firewall

NOTE: this code is compiling but several of the UT are failing.
Main reason is that Metadata is complicated to initialize. 

See the function buildContext() in plugin/themis/attrholder_test.go
- problem is to initialze a ctx for Metadata. There is no other way than to "run" the context through a metadata plugin function ServeDNS().