### PR TITLE
Policy engine for OPA

### DIFF
--- a/plugin/opa/README.md
+++ b/plugin/opa/README.md
@@ -1,0 +1,102 @@
+# opa
+
+*opa* - enables OPA to be used as a CoreDNS _firewall_ policy engine.
+
+## Syntax
+
+```
+opa ENGINE-NAME {
+    endpoint URL
+    tls CERT KEY CACERT
+    fields FIELD [FIELD...]
+}
+```
+
+* **ENGINE-NAME** is the name of the policy engine, used by the firewall
+  plugin to uniquely identify the instance. Each instance of _opa_ in
+  the Corefile must have a unique **ENGINE-NAME**.
+
+* `endpoint` defines the OPA endpoint **URL**.  It should include the
+  full path to the rule.
+
+* `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA
+  cert file names for the OPA connection.
+   
+* `fields` lists the fields that will be sent to OPA when evaluating the
+  policy for a DNS request/response. Fields available are the same as in
+  *firewall* plugin expresions: *metadata* from other plugins, and data
+  from the request/response ("type", "name", "proto", "client_ip", etc).
+  See the *firewall* README for a list. If this option is omitted, the
+  following fields are sent: "client_ip", "name", "rcode", "response_ip"
+
+
+## Firewall Policy Engine
+
+This plugin is not a standalone plugin.  It must be used in conjunction
+with the _firewall_ plugin to function. For this plugin to be active,
+the _firewall_ plugin must reference it in a rule.  See the "Policy
+Engine Plugins" section of the _firewall_ plugin README for more
+information.
+
+## Writing the OPA Policy
+
+This plugin assumes that the rule referenced in the `endpoint` URL will
+evaluate to one of following values:
+* "allow" - allows the dns request/response to proceed as normal
+* "refuse" - sends a REFUSED response to the client
+* "block" - sends a NXDOMAIN response to the client
+* "drop" - sends no response to the client
+
+When writing a rules in OPA, all `fields` are available as input.
+
+## Examples
+
+Point to a local OPA instance using a rule named `action` in the `dns`
+package.
+
+~~~ txt
+. {
+  opa myengine {
+        endpoint http://127.0.0.1:8181/v1/data/dns/action
+  }
+
+  firewall query {
+    opa myengine
+  }
+}
+~~~
+
+The following is an example OPA package. It implements a simple name
+blacklist, while whitelisting a client subnet. The rule "action" allows
+any request from clients with an IP address in the `1.2.3.0/24` network.
+For all other clients it  blocks `a.example.com.`, refuses
+`b.example.com`, and drops requests for `x.example.com`. It allows all
+other requests.
+
+~~~ rego
+package dns
+  
+import input.name
+import input.client_ip
+
+default action = "allow"
+
+# Action Priority
+action = "allow" {
+  allow
+} else = "refuse" {
+  refuse
+} else = "block" {
+  block
+} else = "drop" {
+  drop
+}
+
+block { name == "a.example.com." }
+
+refuse { name == "b.example.com." }
+
+drop { name == "x.example.com." }
+
+allow { net.cidr_contains("1.2.3.0/24", client_ip) }
+~~~

--- a/plugin/opa/opa.go
+++ b/plugin/opa/opa.go
@@ -1,0 +1,141 @@
+package opa
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metadata"
+	"github.com/coredns/coredns/request"
+	"github.com/coredns/policy/plugin/firewall/policy"
+	"github.com/coredns/policy/plugin/pkg/rqdata"
+	"github.com/miekg/dns"
+)
+
+// opa is a policy engine plugin for the firewall plugin that can validate DNS requests and
+// replies against OPA servers.
+type opa struct {
+	engines map[string]*engine
+	next    plugin.Handler
+}
+
+// engine can validate DNS requests and replies against an OPA server.
+type engine struct {
+	endpoint string // url to opa server api package e.g. http://example.com/v1/data/dns
+	client   *http.Client
+	fields   []string        // fields to send as input to opa
+	mapping  *rqdata.Mapping // store this so we dont have to rebuild it for every request
+}
+
+type input map[string]string
+
+func newOpa() *opa {
+	return &opa{engines: make(map[string]*engine)}
+}
+
+func newEngine(m *rqdata.Mapping) *engine {
+	return &engine{
+		mapping: m,
+		fields:  []string{"client_ip", "name", "rcode", "response_ip"},
+	}
+}
+
+// Name implements the Handler interface
+func (p *opa) Name() string { return "opa" }
+
+// ServeDNS implements the Handler interface
+func (p *opa) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	// do nothing
+	return plugin.NextOrFailure(p.Name(), p.next, ctx, w, r)
+}
+
+// Engine implements the policy.Engineer interface
+func (p *opa) Engine(name string) policy.Engine {
+	return p.engines[name]
+}
+
+// BuildQueryData implements the policy.Engine interface
+func (e *engine) BuildQueryData(ctx context.Context, state request.Request) (interface{}, error) {
+	return e.buildData(ctx, state, make(input)), nil
+}
+
+// BuildReplyData implements the policy.Engine interface
+func (e *engine) BuildReplyData(ctx context.Context, state request.Request, queryData interface{}) (interface{}, error) {
+	return e.buildData(ctx, state, queryData.(input)), nil
+}
+
+// BuildRule implements the policy.Engine interface
+func (e *engine) BuildRule(args []string) (policy.Rule, error) { return e, nil }
+
+// Evaluate implements the policy.Rule interface
+func (e *engine) Evaluate(data interface{}) (int, error) {
+	// put all query/response data in "input" field, and marshal to json
+	bdata, err := json.Marshal(map[string]interface{}{"input": data})
+	if err != nil {
+		return 0, err
+	}
+
+	// send to opa api
+	resp, err := e.client.Post(e.endpoint, "application/json", bytes.NewBuffer(bdata))
+	if err != nil {
+		return 0, err
+	}
+
+	// decode response
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		return 0, err
+	}
+	action, ok := result["result"]
+	if !ok {
+		return policy.TypeNone, nil
+	}
+	switch action {
+	case "refuse":
+		return policy.TypeRefuse, nil
+	case "allow":
+		return policy.TypeAllow, nil
+	case "block":
+		return policy.TypeBlock, nil
+	case "drop":
+		return policy.TypeDrop, nil
+	default:
+		return 0, fmt.Errorf("unknown action: '%s'", action)
+	}
+}
+
+// buildData fills the map of values for policy input
+func (e *engine) buildData(ctx context.Context, state request.Request, data input) input {
+	extractor := rqdata.NewExtractor(state, e.mapping)
+	for _, f := range e.fields {
+		if _, ok := data[f]; ok {
+			// skip if already defined
+			continue
+		}
+		var v string
+		var ok bool
+		if e.mapping.ValidField(f) {
+			v, ok = extractor.Value(f)
+			if !ok {
+				continue
+			}
+		} else {
+			mdf := metadata.ValueFunc(ctx, f)
+			v = mdf()
+			if v == "" {
+				continue
+			}
+		}
+		// strip brackets from ipv6 addresses in *_ip fields
+		if len(v) > 0 && v[0] == '[' && strings.HasSuffix(f, "_ip") {
+			v = v[1 : len(v)-1]
+		}
+		data[f] = v
+	}
+	return data
+}

--- a/plugin/opa/opa_test.go
+++ b/plugin/opa/opa_test.go
@@ -1,0 +1,57 @@
+package opa
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/caddyserver/caddy"
+	"github.com/coredns/policy/plugin/firewall/policy"
+)
+
+func TestEvaluate(t *testing.T) {
+
+	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		decoder := json.NewDecoder(r.Body)
+		var result map[string]map[string]string
+		err := decoder.Decode(&result)
+		if err != nil {
+			w.Write([]byte("{\"result\":\"json decode error\"}"))
+		}
+		if _, ok := result["input"]; !ok {
+			w.Write([]byte("{\"result\":\"request did not contain input\"}"))
+		}
+		if result["input"]["a"] != "1" {
+			w.Write([]byte("{\"result\":\"expected a -> 1\"}"))
+		}
+		if result["input"]["b"] != "2" {
+			w.Write([]byte("{\"result\":\"expected b -> 2\"}"))
+		}
+
+		w.Write([]byte("{\"result\":\"allow\"}"))
+	}))
+
+	o, err := parse(caddy.NewTestController("dns",
+		`opa myengine {
+                 endpoint `+ apiStub.URL +`
+               }`,
+	))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := map[string]string{"a": "1", "b": "2"}
+
+	result, err := o.engines["myengine"].Evaluate(data)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != policy.TypeAllow {
+		t.Errorf("Expected %d, got %d.", policy.TypeAllow, result)
+	}
+}

--- a/plugin/opa/setup.go
+++ b/plugin/opa/setup.go
@@ -1,0 +1,80 @@
+package opa
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	"github.com/caddyserver/caddy"
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	pkgtls "github.com/coredns/coredns/plugin/pkg/tls"
+	"github.com/coredns/policy/plugin/pkg/rqdata"
+)
+
+func init() {
+	caddy.RegisterPlugin("opa", caddy.Plugin{
+		ServerType: "dns",
+		Action:     setup,
+	})
+}
+
+func setup(c *caddy.Controller) error {
+	o, err := parse(c)
+	if err != nil {
+		return err
+	}
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		o.next = next
+		return o
+	})
+	return nil
+}
+
+func parse(c *caddy.Controller) (*opa, error) {
+	o := newOpa()
+	mapping := rqdata.NewMapping("")
+	for c.Next() {
+		args := c.RemainingArgs()
+		if len(args) != 1 {
+			return nil, c.ArgErr()
+		}
+		name := args[0]
+		eng := newEngine(mapping)
+		var tlsConfig *tls.Config
+		for c.NextBlock() {
+			switch c.Val() {
+			case "endpoint":
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return nil, c.ArgErr()
+				}
+				eng.endpoint = args[0]
+			case "fields":
+				args := c.RemainingArgs()
+				if len(args) == 0 {
+					return nil, c.ArgErr()
+				}
+				// these fields cannot be validated, because metadata fields are not known at setup time
+				eng.fields = args
+			case "tls": // cert key cacertfile
+				args := c.RemainingArgs()
+				if len(args) == 3 {
+					var err error
+					tlsConfig, err = pkgtls.NewTLSConfigFromArgs(args...)
+					if err != nil {
+						return nil, err
+					}
+					tlsConfig.BuildNameToCertificate()
+					continue
+				}
+				return nil, c.ArgErr()
+			}
+		}
+		if eng.endpoint == "" {
+			return nil, c.Err("endpoint required")
+		}
+		eng.client = &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+		o.engines[name] = eng
+	}
+	return o, nil
+}

--- a/plugin/opa/setup_test.go
+++ b/plugin/opa/setup_test.go
@@ -1,0 +1,101 @@
+package opa
+
+import (
+	"testing"
+
+	"github.com/caddyserver/caddy"
+)
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		input     string
+		expected  *opa
+		shouldErr bool
+	}{
+		{"opa testengine", nil, true},
+
+		{`opa test engine {
+                  endpoint test
+                }`,
+			nil,
+			true,
+		},
+
+		{`opa testengine {
+                  endpoint test
+                  fields 1 2 3
+                }`,
+			&opa{engines: map[string]*engine{
+				"testengine": {endpoint: "test", fields: []string{"1", "2", "3"}},
+			}},
+			false,
+		},
+
+		{`opa testengine {
+                  endpoint test
+                  fields 1 2 3
+                }
+                opa testengine2 {
+                  endpoint test2
+                  fields 4
+                }`,
+			&opa{engines: map[string]*engine{
+				"testengine":  {endpoint: "test", fields: []string{"1", "2", "3"}},
+				"testengine2": {endpoint: "test2", fields: []string{"4"}},
+			}},
+			false,
+		},
+	}
+
+	for i, test := range cases {
+		c := caddy.NewTestController("dns", test.input)
+		o, err := parse(c)
+
+		if test.shouldErr && err != nil {
+			continue
+		}
+
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: expected error but didn't get one for input %s", i, test.input)
+		}
+
+		if err != nil {
+			if !test.shouldErr {
+				t.Errorf("Test %d: expected no error but got one for input %s, got: %v", i, test.input, err)
+			}
+		}
+
+		if o == nil {
+			t.Errorf("Test %d: got nil result for input %s", i, test.input)
+		}
+
+		if o.engines == nil {
+			t.Errorf("Test %d: got nil engines result for input %s", i, test.input)
+			continue
+		}
+
+		for name, e := range o.engines {
+			if e.endpoint != test.expected.engines[name].endpoint {
+				t.Errorf("Test %d: engine '%s' expected endpoint %s, got %s", i, name, test.expected.engines[name].endpoint, e.endpoint)
+			}
+
+			if !equal(e.fields, test.expected.engines[name].fields) {
+				t.Errorf("Test %d: engine '%s' expected fields %v, got %v", i, name, test.expected.engines[name].fields, e.fields)
+			}
+
+		}
+	}
+
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/plugin/pkg/rqdata/rqdata.go
+++ b/plugin/pkg/rqdata/rqdata.go
@@ -122,6 +122,11 @@ func NewMapping(emptyValue string) *Mapping {
 	return &Mapping{replacements, emptyValue}
 }
 
+func (m *Mapping) ValidField(name string) (bool) {
+	_, ok := m.replacements[name]
+	return ok
+}
+
 // Value extract the data that is mapped to this name and return the corresponding value as a string
 // if that value is empty then the defaultValue is returned
 // Second parameter is a boolean that inform if the name itself is supported in the mapping


### PR DESCRIPTION
This adds a CoreDNS Policy plugin engine implementation for OPA.  It integrates with a standalone OPA server via web api (does not evaluate locally with opa go libs).
More details in the README. The README describes how to construct a compatible opa policy, and shows a very simplistic example of an OPA rego policy.

todo:
* Need to flesh out unit tests more, and plug into travis ci
* Should also add integration tests to coredns/ci