### PR TITLE
Remove response_ip field, fix/add/adjusts tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Available actions:
   * `>opcode`: query OPCODE
   * `server_ip`: server's IP address, for IPv6 addresses these are enclosed in brackets: `[::1]`
   * `server_port` : client's port
-  * `response_ip` : the IP returned in the first A or AAAA record of the Answer section
 
 * **POLICY-PLUGIN** : is the name of another plugin that implements a firewall policy engine. 
   **ENGINE-NAME** is the name of an engine defined in your Corefile. Requests/responses will be evaluated by

--- a/plugin/opa/README.md
+++ b/plugin/opa/README.md
@@ -27,7 +27,7 @@ opa ENGINE-NAME {
   *firewall* plugin expresions: *metadata* from other plugins, and data
   from the request/response ("type", "name", "proto", "client_ip", etc).
   See the *firewall* README for a list. If this option is omitted, the
-  following fields are sent: "client_ip", "name", "rcode", "response_ip"
+  following fields are sent: "client_ip", "name", "rcode"
 
 
 ## Firewall Policy Engine

--- a/plugin/opa/opa.go
+++ b/plugin/opa/opa.go
@@ -40,7 +40,7 @@ func newOpa() *opa {
 func newEngine(m *rqdata.Mapping) *engine {
 	return &engine{
 		mapping: m,
-		fields:  []string{"client_ip", "name", "rcode", "response_ip"},
+		fields:  []string{"client_ip", "name", "rcode"},
 	}
 }
 

--- a/plugin/pkg/rqdata/rqdata.go
+++ b/plugin/pkg/rqdata/rqdata.go
@@ -1,7 +1,6 @@
 package rqdata
 
 import (
-	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -111,13 +110,6 @@ func NewMapping(emptyValue string) *Mapping {
 		"server_port": func(state request.Request) string {
 			return addrToRFC3986(state.LocalPort())
 		},
-		"response_ip": func(state request.Request) string {
-			ip := respIP(state.Req)
-			if ip != nil {
-				return addrToRFC3986(ip.String())
-			}
-			return ""
-		},
 	}
 	return &Mapping{replacements, emptyValue}
 }
@@ -197,28 +189,4 @@ func addrToRFC3986(addr string) string {
 		return "[" + addr + "]"
 	}
 	return addr
-}
-
-// respIP return the first A or AAAA records found in the Answer of the DNS msg
-func respIP(r *dns.Msg) net.IP {
-	if r == nil {
-		return nil
-	}
-
-	var ip net.IP
-	for _, rr := range r.Answer {
-		switch rr := rr.(type) {
-		case *dns.A:
-			ip = rr.A
-
-		case *dns.AAAA:
-			ip = rr.AAAA
-		}
-		// If there are several responses, currently
-		// only return the first one and break.
-		if ip != nil {
-			break
-		}
-	}
-	return ip
 }

--- a/plugin/pkg/rqdata/rqdata_test.go
+++ b/plugin/pkg/rqdata/rqdata_test.go
@@ -33,7 +33,7 @@ func buildExtractorOnRepliedMsg(mapping *Mapping) *Extractor {
 	ret.SetReply(r)
 	ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.1"))
 	w.WriteMsg(ret)
-	state := request.Request{Req: ret, W: w}
+	state := request.Request{Req: r, W: w}
 
 	return &Extractor{state, mapping}
 }
@@ -55,7 +55,7 @@ func TestNewRequestData(t *testing.T) {
 		{extractFromQuery, "size", "29", "", false},
 		{extractFromQuery, "duration", "", "s", false},
 		{extractFromQuery, "invalid", "", "", true},
-		{extractFromReply, "response_ip", "127.0.0.1", "", false},
+		{extractFromReply, "rcode", "NOERROR", "", false},
 	}
 
 	for i, tst := range tests {

--- a/plugin/themis/attrholder.go
+++ b/plugin/themis/attrholder.go
@@ -207,16 +207,6 @@ func (ah *attrHolder) putCustomAttr(attr pdp.AttributeAssignment, f custAttr) {
 	}
 }
 
-func (ah *attrHolder) prepareResponseFromContext(ctx context.Context, xtr *rq.Extractor) {
-	ipResp, _ := xtr.Value("response_ip")
-	if ipResp != "" {
-		ip := net.ParseIP(ipResp)
-		if ip != nil {
-			ah.addIPReq(ip)
-		}
-	}
-}
-
 func (ah *attrHolder) addIPReq(ip net.IP) {
 	ah.ipReq = append(
 		[]pdp.AttributeAssignment{

--- a/plugin/themis/themis.go
+++ b/plugin/themis/themis.go
@@ -58,7 +58,6 @@ func (p *ThemisEngine) BuildQueryData(ctx context.Context, state request.Request
 
 func (p *ThemisEngine) BuildReplyData(ctx context.Context, state request.Request, queryData interface{}) (interface{}, error) {
 	ah := queryData.(*attrHolder)
-	ah.prepareResponseFromContext(ctx, rqdata.NewExtractor(state, p.mapping))
 	return ah, nil
 }
 


### PR DESCRIPTION
When testing the opa plugin, I found that the `response_ip` field in firewall was incorrectly pulling data from the _request_ not the _response_ of the state, and unit tests for it were constructed in an artificial way to make the function work.  Unfortunately, the response in the state object (via the responsewriter) is private, so we cannot see it.