### PR TITLE
Remove all invalid response data extractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ Available actions:
   * `client_ip`: client's IP address, for IPv6 addresses these are enclosed in brackets: `[::1]`
   * `size`: request size in bytes
   * `port`: client's port
-  * `duration`: response duration
-  * `rcode`: response CODE (NOERROR, NXDOMAIN, SERVFAIL, ...)
-  * `rsize`: raw (uncompressed), response size (a client may receive a smaller response)
-  * `>rflags`: response flags, each set flag will be displayed, e.g. "aa, tc". This includes the qr
-    bit as well
   * `>bufsize`: the EDNS0 buffer size advertised in the query
   * `>do`: is the EDNS0 DO (DNSSEC OK) bit set in the query
   * `>id`: query ID

--- a/plugin/opa/opa.go
+++ b/plugin/opa/opa.go
@@ -40,7 +40,7 @@ func newOpa() *opa {
 func newEngine(m *rqdata.Mapping) *engine {
 	return &engine{
 		mapping: m,
-		fields:  []string{"client_ip", "name", "rcode"},
+		fields:  []string{"client_ip", "name"},
 	}
 }
 

--- a/plugin/opa/opa_test.go
+++ b/plugin/opa/opa_test.go
@@ -109,7 +109,4 @@ func TestBuildReplyData(t *testing.T) {
 	if data["name"] != "test.data.exists." {
 		t.Errorf("expected name == 'test.data.exists.'. Got '%v'", data["name"])
 	}
-	if data["rcode"] != "NOERROR" {
-		t.Errorf("expected rcode == 'NOERROR'. Got '%v'", data["rcode"])
-	}
 }

--- a/plugin/pkg/rqdata/rqdata.go
+++ b/plugin/pkg/rqdata/rqdata.go
@@ -3,9 +3,7 @@ package rqdata
 import (
 	"strconv"
 	"strings"
-	"time"
 
-	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -56,41 +54,6 @@ func NewMapping(emptyValue string) *Mapping {
 		},
 		"port": func(state request.Request) string {
 			return addrToRFC3986(state.Port())
-		},
-		"rcode": func(state request.Request) string {
-			rcode := ""
-			rr, ok := state.W.(*dnstest.Recorder)
-			if ok {
-				rcode = dns.RcodeToString[rr.Rcode]
-			}
-			if rr != nil && rcode == "" {
-				rcode = strconv.Itoa(rr.Rcode)
-			}
-			return rcode
-		},
-		"rsize": func(state request.Request) string {
-			rsize := ""
-			rr, ok := state.W.(*dnstest.Recorder)
-			if ok {
-				rsize = strconv.Itoa(rr.Len)
-			}
-			return rsize
-		},
-		"duration": func(state request.Request) string {
-			duration := ""
-			rr, ok := state.W.(*dnstest.Recorder)
-			if ok {
-				duration = strconv.FormatFloat(time.Since(rr.Start).Seconds(), 'f', -1, 64) + "s"
-			}
-			return duration
-		},
-		">rflags": func(state request.Request) string {
-			flags := ""
-			rr, ok := state.W.(*dnstest.Recorder)
-			if ok && rr.Msg != nil {
-				flags = flagsToString(rr.Msg.MsgHdr)
-			}
-			return flags
 		},
 		">id": func(state request.Request) string {
 			return strconv.Itoa(int(state.Req.Id))

--- a/plugin/pkg/rqdata/rqdata_test.go
+++ b/plugin/pkg/rqdata/rqdata_test.go
@@ -23,26 +23,10 @@ func buildExtractorOnSimpleMsg(mapping *Mapping) *Extractor {
 	return &Extractor{state, mapping}
 }
 
-func buildExtractorOnRepliedMsg(mapping *Mapping) *Extractor {
-	w := dnstest.NewRecorder(&test.ResponseWriter{})
-
-	r := new(dns.Msg)
-	r.SetQuestion("example.org.", dns.TypeA)
-
-	ret := new(dns.Msg)
-	ret.SetReply(r)
-	ret.Answer = append(ret.Answer, test.A("example.org. IN A 127.0.0.1"))
-	w.WriteMsg(ret)
-	state := request.Request{Req: r, W: w}
-
-	return &Extractor{state, mapping}
-}
-
 func TestNewRequestData(t *testing.T) {
 
 	mapping := NewMapping("")
 	extractFromQuery := buildExtractorOnSimpleMsg(mapping)
-	extractFromReply := buildExtractorOnRepliedMsg(mapping)
 	tests := []struct {
 		extractor *Extractor
 		name      string
@@ -53,13 +37,10 @@ func TestNewRequestData(t *testing.T) {
 		{extractFromQuery, "type", "HINFO", "", false},
 		{extractFromQuery, "name", "example.org.", "", false},
 		{extractFromQuery, "size", "29", "", false},
-		{extractFromQuery, "duration", "", "s", false},
 		{extractFromQuery, "invalid", "", "", true},
-		{extractFromReply, "rcode", "NOERROR", "", false},
 	}
 
 	for i, tst := range tests {
-
 		d, ok := tst.extractor.Value(tst.name)
 		if !ok {
 			if !tst.error {


### PR DESCRIPTION
Response data extractions were done in a way that would only work in the context of tests.
Outside of that context, they will have always returned empty strings. This PR removes them, since it's not really possible to extract response data from the state.  This data can instead be exposed via metadata.

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>