### PR TITLE
Add Kubernetes multi-tenancy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,29 @@ example.org {
 }
 ~~~
 
+### Kubernetes Metadata Multi-Tenancy Policy
+This example shows how *firewall* could be useful in a Kubernetes based multi-tenancy application. It uses the *kubernetes*
+plugin metadata to prevent Pods in certain Namespaces from looking up Services in other Namespaces.
+Specifically, if the requesting Pod is in a Namespace beginning with 'tenant-', it permits only lookups to
+Services that are in the same Namespace or in the 'default' Namespace. Note here that `pods verified` is
+required in the *kubernetes* plugin to enable the `[kubernetes/client-namespace]` metadata variable.  Also note that
+this is at the DNS level only, and does not prevent network access between tenant Namespaces, e.g. if Service IPs are known.
+
+~~~ corefile
+cluster.local {
+   metadata
+   kubernetes {
+      pods verified
+   }
+   firewall query {
+      allow [kubernetes/client-namespace] !~ '^tenant-'
+      allow [kubernetes/namespace] == [kubernetes/client-namespace]
+      allow [kubernetes/namespace] == 'default'
+      block true
+   }
+}
+~~~
+
 ### Using a Policy Engine Plugin
 
 The following example illustrates how the a policy engine plugin (*themis* in this example) can be used by the *firewall* plugin.


### PR DESCRIPTION
Add a simplified Kubernetes multi-tenancy example.

This example sidesteps a known [bug](coredns/coredns#3642), by specifying the zone in the server block.  Specifying the zone in the serverblock does not handle reverse zones well (for [reasons](https://github.com/coredns/deployment/issues/153)) - so i left them out.  Once  coredns/coredns#3642 is merged and released, the example should be updated to be more in line with the default Kubernetes CoreDNS Corefile deployment, which handles reverse zones better.