### PR TITLE
Add incidr function

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,44 +35,56 @@ Available actions:
   - `block` : interrupt the DNS resolution, reply with NXDOMAIN response code
   - `drop` : interrupt the DNS resolution, do not reply (client will time out)
 
-  An action must be followed by an **EXPRESSION**, which defines the boolean expression for the rule.  Expression uses 
-  a [c-like expression format](https://github.com/Knetic/govaluate/blob/master/MANUAL.md) where the variables are either
-  the `metadata` of CoreDNS or the fields of a DNS query/response.  Common operators apply.
-
-  Expression Examples:
-  * `client_ip == '10.0.0.20'`
-  * `type == 'AAAA'`
-  * `type IN ('AAAA', 'A', 'TXT')`
-  * `type IN ('AAAA', 'A') && name =~ 'google.com'`
-  * `[mac/address] =~ '.*:FF:.*'`
-
-  NOTE: because of the `/` separator included in a label of metadata, those labels must be enclosed in
-  brackets `[...]`.
-
-  The following names are supported for querying information in expressions
-
-  * `type`: type of the request (A, AAAA, TXT, ...)
-  * `name`: name of the request (the domain name requested)
-  * `class`: class of the request (IN, CH, ...)
-  * `proto`: protocol used (tcp or udp)
-  * `client_ip`: client's IP address, for IPv6 addresses these are enclosed in brackets: `[::1]`
-  * `size`: request size in bytes
-  * `port`: client's port
-  * `rcode`: response CODE (NOERROR, NXDOMAIN, SERVFAIL, ...)
-  * `rsize`: raw (uncompressed), response size (a client may receive a smaller response)
-  * `>rflags`: response flags, each set flag will be displayed, e.g., "aa, tc". This includes the qr
-    bit as well
-  * `>bufsize`: the EDNS0 buffer size advertised in the query
-  * `>do`: the EDNS0 DO (DNSSEC OK) bit set in the query
-  * `>id`: query ID
-  * `>opcode`: query OPCODE
-  * `server_ip`: server's IP address; for IPv6 addresses these are enclosed in brackets: `[::1]`
-  * `server_port` : client's port
-  * `response_ip` : the IP address returned in the first A or AAAA record of the Answer section
+  An action must be followed by an **EXPRESSION**, which defines the boolean expression for the rule.  See Expressions 
+  section below.
 
 * **POLICY-PLUGIN** : is the name of another plugin that implements a firewall policy engine. 
   **ENGINE-NAME** is the name of an engine defined in your Corefile. Requests/responses will be evaluated by
   that plugin policy engine to determine the action.
+
+## Expressions
+
+Expressions follow a [c-like expression format](https://github.com/Knetic/govaluate/blob/master/MANUAL.md) where the variables are either
+the `metadata` of CoreDNS or the fields of a DNS query/response.  Common operators apply.
+
+Expression Examples:
+* `client_ip == '10.0.0.20'`
+* `type == 'AAAA'`
+* `type IN ('AAAA', 'A', 'TXT')`
+* `type IN ('AAAA', 'A') && name =~ 'google.com'`
+* `[mac/address] =~ '.*:FF:.*'`
+
+NOTE: because of the `/` separator included in a label of metadata, those labels must be enclosed in
+brackets `[...]`.
+
+### Expression Variables
+
+The following variables are supported for querying information in expressions.  All values are strings (see `atoi` function
+below for arithmetic operations).
+
+* `type`: type of the request (A, AAAA, TXT, ...)
+* `name`: name of the request (the domain name requested)
+* `class`: class of the request (IN, CH, ...)
+* `proto`: protocol used (tcp or udp)
+* `client_ip`: client's IP address, for IPv6 addresses these are enclosed in brackets: `[::1]`
+* `size`: request size in bytes
+* `port`: client's port
+* `rcode`: response CODE (NOERROR, NXDOMAIN, SERVFAIL, ...)
+* `rsize`: raw (uncompressed), response size (a client may receive a smaller response)
+* `>rflags`: response flags, each set flag will be displayed, e.g., "aa, tc". This includes the qr
+  bit as well
+* `>bufsize`: the EDNS0 buffer size advertised in the query
+* `>do`: the EDNS0 DO (DNSSEC OK) bit set in the query
+* `>id`: query ID
+* `>opcode`: query OPCODE
+* `server_ip`: server's IP address; for IPv6 addresses these are enclosed in brackets: `[::1]`
+* `server_port` : client's port
+* `response_ip` : the IP address returned in the first A or AAAA record of the Answer section
+
+### Expression Functions
+
+* `atoi(string)`: convert a string to a numeric value.
+* `incidr(ip, cidr)`: returns true if `ip` is in the subnet defined by `cidr`.
 
 ## Policy Engine Plugins
 

--- a/plugin/firewall/policy/expression.go
+++ b/plugin/firewall/policy/expression.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -54,6 +55,7 @@ func (x *ExprEngine) BuildRule(args []string) (Rule, error) {
 	exp := args[1:]
 	e, err := expr.NewEvaluableExpressionWithFunctions(strings.Join(exp, " "), map[string]expr.ExpressionFunction{
 		"atoi": atoi,
+		"incidr": incidr,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot create a valid expression : %s", err)
@@ -84,6 +86,21 @@ func atoi(arguments ...interface{}) (interface{}, error) {
 		return nil, err
 	}
 	return float64(n), nil
+}
+
+func incidr(args ...interface{}) (interface{}, error) {
+	if len(args) != 2 {
+		return nil, fmt.Errorf("invalid number of arguments")
+	}
+	ip := net.ParseIP(args[0].(string))
+	if ip == nil {
+		return nil, fmt.Errorf("first argument is not an IP address")
+	}
+	_, cidr, err := net.ParseCIDR(args[1].(string))
+	if err != nil {
+		return nil, err
+	}
+	return cidr.Contains(ip), nil
 }
 
 func toBoolean(v interface{}) (bool, error) {

--- a/plugin/firewall/policy/expression_test.go
+++ b/plugin/firewall/policy/expression_test.go
@@ -9,6 +9,7 @@ import (
 
 	tst "github.com/coredns/coredns/plugin/test"
 	"github.com/coredns/coredns/request"
+
 	"github.com/coredns/policy/plugin/pkg/response"
 	"github.com/coredns/policy/plugin/pkg/rqdata"
 
@@ -92,6 +93,7 @@ func TestRuleEvaluate(t *testing.T) {
 		{"name =~ 'org'", true, false},
 		{"atoi('4') == 4.0", true, false},
 		{"incidr('1.2.3.4','1.2.3.0/24')", true, false},
+		{"incidr('1:2:3:4::1','1:2:3:4::/32')", true, false},
 	}
 	for i, test := range tests {
 
@@ -183,6 +185,14 @@ func TestInCidr(t *testing.T) {
 		},
 		{
 			args:     []interface{}{"1.2.3.4", "5.6.7.0/24"},
+			expected: false,
+		},
+		{
+			args:     []interface{}{"1:2:3:4::1", "1:2:3:4::/32"},
+			expected: true,
+		},
+		{
+			args:     []interface{}{"1:2:3:4::1", "5:6:7:8::/32"},
 			expected: false,
 		},
 		{

--- a/plugin/firewall/policy/expression_test.go
+++ b/plugin/firewall/policy/expression_test.go
@@ -91,6 +91,7 @@ func TestRuleEvaluate(t *testing.T) {
 		{"type == 'AAAA'", false, false},
 		{"name =~ 'org'", true, false},
 		{"atoi('4') == 4.0", true, false},
+		{"incidr('1.2.3.4','1.2.3.0/24')", true, false},
 	}
 	for i, test := range tests {
 
@@ -155,6 +156,46 @@ func TestAtoi(t *testing.T) {
 	}
 	for i, test := range tests {
 		v, err := atoi(test.args...)
+		if test.expectedErr != nil {
+			if err == nil {
+				t.Errorf("Test %d, args : %v - expected error - expected : %v, got : %v", i, test.args, test.expectedErr, nil)
+			} else if err.Error() != test.expectedErr.Error() {
+				t.Errorf("Test %d, args : %v - expected error - expected : %v, got : %v", i, test.args, test.expectedErr, err)
+			}
+			continue
+		}
+
+		if !reflect.DeepEqual(v, test.expected) {
+			t.Errorf("Test %d, args : %v -  value return is not the one expected - expected : %v, got : %v", i, test.args, test.expected, v)
+		}
+	}
+}
+
+func TestInCidr(t *testing.T) {
+	tests := []struct {
+		args        []interface{}
+		expected    interface{}
+		expectedErr error
+	}{
+		{
+			args:     []interface{}{"1.2.3.4", "1.2.3.0/24"},
+			expected: true,
+		},
+		{
+			args:     []interface{}{"1.2.3.4", "5.6.7.0/24"},
+			expected: false,
+		},
+		{
+			args:        []interface{}{"1.2.3.4"},
+			expectedErr: fmt.Errorf("invalid number of arguments"),
+		},
+		{
+			args:        []interface{}{"foo", "5.6.7.0/24"},
+			expectedErr: fmt.Errorf("first argument is not an IP address"),
+		},
+	}
+	for i, test := range tests {
+		v, err := incidr(test.args...)
 		if test.expectedErr != nil {
 			if err == nil {
 				t.Errorf("Test %d, args : %v - expected error - expected : %v, got : %v", i, test.args, test.expectedErr, nil)


### PR DESCRIPTION
Adds a function for checking ip/subnet inclusion.

Copied over from chrisohaver/conditional.

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>