### PR TITLE
Add random function

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ below for arithmetic operations).
 
 * `atoi(string)`: convert a string to a numeric value.
 * `incidr(ip, cidr)`: returns true if `ip` is in the subnet defined by `cidr`.
+* `random()`: returns a random floating point number in the range [0.0, 1.0).
 
 ## Policy Engine Plugins
 

--- a/plugin/firewall/policy/expression.go
+++ b/plugin/firewall/policy/expression.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net"
 	"strconv"
 	"strings"
@@ -54,8 +55,9 @@ func (x *ExprEngine) BuildRule(args []string) (Rule, error) {
 	keyword := args[0]
 	exp := args[1:]
 	e, err := expr.NewEvaluableExpressionWithFunctions(strings.Join(exp, " "), map[string]expr.ExpressionFunction{
-		"atoi": atoi,
+		"atoi":   atoi,
 		"incidr": incidr,
+		"random": random,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot create a valid expression : %s", err)
@@ -71,6 +73,13 @@ func (x *ExprEngine) BuildRule(args []string) (Rule, error) {
 		return nil, fmt.Errorf("invalid keyword %s for a policy rule", keyword)
 	}
 	return &ruleExpr{kind, x.actionIfErrorEvaluation, e}, nil
+}
+
+func random(arguments ...interface{}) (interface{}, error) {
+	if len(arguments) != 0 {
+		return nil, fmt.Errorf("invalid number of arguments")
+	}
+	return rand.Float64(), nil
 }
 
 func atoi(arguments ...interface{}) (interface{}, error) {

--- a/plugin/firewall/policy/expression_test.go
+++ b/plugin/firewall/policy/expression_test.go
@@ -94,6 +94,9 @@ func TestRuleEvaluate(t *testing.T) {
 		{"atoi('4') == 4.0", true, false},
 		{"incidr('1.2.3.4','1.2.3.0/24')", true, false},
 		{"incidr('1:2:3:4::1','1:2:3:4::/32')", true, false},
+		{"random() < 1.0", true, false},
+		{"random() >= 0.0", true, false},
+		{"random('1') >= 0.0", true, true},
 	}
 	for i, test := range tests {
 
@@ -114,6 +117,10 @@ func TestRuleEvaluate(t *testing.T) {
 		state := request.Request{Req: r, W: w}
 
 		data, err := engine.BuildQueryData(ctx, state)
+		if err != nil {
+			t.Errorf("Test %d, expr : %s - unexpected error at build query data : %s", i, test.expression, err)
+			continue
+		}
 		result, err := rule.Evaluate(data)
 		if err != nil {
 			if !test.errorExec {


### PR DESCRIPTION
The atoi function was added in #32 to enable policy expressions to make
decisions with a random chance based on the transaction ID. The client
*should* generate unpredictable transaction IDs from a uniform
distribution, but many client libraries reuse the same transaction ID
when retrying a query. Therefore, deterministically dropping queries
based on the transaction ID doesn't work well for simulating packet
loss, as retries will never succeed.

The random function enables policies to take action with random chance,
without depending on the client for the quality of randomness:
```
firewall query {
  # 5% chance to drop
  drop random() < 0.05
  allow true
}
```