### PR TITLE
added support for evaluating IPs from all the records of the answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ below for arithmetic operations).
 * `server_ip`: server's IP address; for IPv6 addresses these are enclosed in brackets: `[::1]`
 * `server_port` : client's port
 * `response_ip` : the IP address returned in the first A or AAAA record of the Answer section
+* `response_ips` : array (represented as a JSON string) of the all the IP addresses returned in the A or AAAA records of the Answer section
 
 ### Expression Functions
 

--- a/plugin/firewall/firewall.go
+++ b/plugin/firewall/firewall.go
@@ -106,15 +106,15 @@ func (p *firewall) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		return dns.RcodeSuccess, nil
 	case policy.TypeBlock:
 		// One of the RuleList ended evaluation with typeBlock : return the initial request with corresponding rcode
-		log.Warning("coredns::policy/firewall, Action is Block")
+		log.Debug("coredns::policy/firewall, Action is Block")
 		status = dns.RcodeNameError
 	case policy.TypeRefuse:
 		// One of the RuleList ended evaluation with typeRefuse : return the initial request with corresponding rcode
-		log.Warning("coredns::policy/firewall, Action is Refuse")
+		log.Debug("coredns::policy/firewall, Action is Refuse")
 		status = dns.RcodeRefused
 	case policy.TypeDrop:
 		// One of the RuleList ended evaluation with typeDrop : simulate a drop
-		log.Warning("coredns::policy/firewall, Action is Drop")
+		log.Debug("coredns::policy/firewall, Action is Drop")
 		return dns.RcodeSuccess, nil
 	default:
 		// Any other action returned by RuleLists is considered an internal error

--- a/plugin/firewall/firewall.go
+++ b/plugin/firewall/firewall.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/nonwriter"
 	"github.com/coredns/coredns/request"
 	"github.com/coredns/policy/plugin/firewall/policy"
@@ -15,6 +16,8 @@ import (
 
 	"github.com/miekg/dns"
 )
+
+var logger = log.NewWithPlugin("firewall")
 
 var (
 	errInvalidAction = errors.New("invalid action")
@@ -103,12 +106,15 @@ func (p *firewall) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		return dns.RcodeSuccess, nil
 	case policy.TypeBlock:
 		// One of the RuleList ended evaluation with typeBlock : return the initial request with corresponding rcode
+		log.Warning("coredns::policy/firewall, Action is Block")
 		status = dns.RcodeNameError
 	case policy.TypeRefuse:
 		// One of the RuleList ended evaluation with typeRefuse : return the initial request with corresponding rcode
+		log.Warning("coredns::policy/firewall, Action is Refuse")
 		status = dns.RcodeRefused
 	case policy.TypeDrop:
 		// One of the RuleList ended evaluation with typeDrop : simulate a drop
+		log.Warning("coredns::policy/firewall, Action is Drop")
 		return dns.RcodeSuccess, nil
 	default:
 		// Any other action returned by RuleLists is considered an internal error

--- a/plugin/pkg/rqdata/rqdata.go
+++ b/plugin/pkg/rqdata/rqdata.go
@@ -116,10 +116,9 @@ func NewMapping(emptyValue string) *Mapping {
 			}
 			return ""
 		},
-		"response_ips": responseIpsExtractor,
-		"response_ips_with_log": func(state request.Request) string {
+		"response_ips": func(state request.Request) string {
 			result := responseIpsExtractor(state)
-			log.Infof("coredns::policy/firewall, Response IPs are: '%s'", result)
+			log.Debugf("coredns::policy/firewall, Response IPs are: '%s'", result)
 			return result
 		},
 	}


### PR DESCRIPTION
On policy rule processing, added support for evaluating IPs from all the records of the DNS answer, and not just the first one